### PR TITLE
Decoding Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 * Rust
 * Postgresql
+* Dependencies: `make, build-essential, libpq-dev, pkg-config, protobuf-compiler`
 
 ## Running
 

--- a/crates/sb_dl/Cargo.toml
+++ b/crates/sb_dl/Cargo.toml
@@ -51,6 +51,8 @@ features = ["log", "attributes"]
 version = "1"
 [dependencies.solana-storage-proto]
 version = "1.18"
+[dependencies.regex]
+version = "1"
 [dependencies.db]
 path = "../db"
 [dependencies.solana-storage-bigtable]

--- a/crates/sb_dl/src/commands/download.rs
+++ b/crates/sb_dl/src/commands/download.rs
@@ -3,6 +3,8 @@ use std::collections::HashSet;
 use clap::ArgMatches;
 use db::migrations::run_migrations;
 use sb_dl::{config::Config, Downloader};
+use solana_transaction_status::UiConfirmedBlock;
+use tokio::signal::unix::{signal, SignalKind};
 
 pub async fn start(matches: &ArgMatches, config_path: &str) -> anyhow::Result<()> {
     let cfg = Config::load(config_path).await?;
@@ -12,7 +14,7 @@ pub async fn start(matches: &ArgMatches, config_path: &str) -> anyhow::Result<()
     let downloader = Downloader::new(cfg.bigtable).await?;
 
     // load all currently indexed block number to avoid re-downloading already indexed block data
-    let mut already_indexed: HashSet<u64> = {
+    let already_indexed: HashSet<u64> = {
         let mut conn = db::new_connection(&cfg.db_url)?;
 
         // perform db migrations
@@ -26,24 +28,61 @@ pub async fn start(matches: &ArgMatches, config_path: &str) -> anyhow::Result<()
             .map(|block| block as u64)
             .collect()
     };
-    log::info!("starting block_indexing. disable_minimization={no_minimization}");
-    let blocks = downloader
-        .start(&mut already_indexed, start, limit, no_minimization)
-        .await?;
 
+    // receives downloaded blocks, which allows us to persist downloaded data while we download and parse other data
+    let (blocks_tx, mut blocks_rx) =
+        tokio::sync::mpsc::channel::<(u64, UiConfirmedBlock)>(limit.unwrap_or(1_000) as usize);
+
+    let mut sig_quit = signal(SignalKind::quit())?;
+    let mut sig_int = signal(SignalKind::interrupt())?;
+    let mut sig_term = signal(SignalKind::terminate())?;
+
+    // if we fail to connect to postgres, we should terminate the thread
     let mut conn = db::new_connection(&cfg.db_url)?;
-    let client = db::client::Client {};
-    for (slot, block) in blocks {
-        match serde_json::to_value(block) {
-            Ok(block) => {
-                if let Err(err) = client.insert_block(&mut conn, slot as i64, block) {
-                    log::error!("failed to persist block({slot}) {err:#?}");
+
+    // start the background persistence task
+    tokio::task::spawn(async move {
+        let client = db::client::Client {};
+
+        while let Some((slot, block)) = blocks_rx.recv().await {
+            match serde_json::to_value(block) {
+                Ok(block) => {
+                    if let Err(err) = client.insert_block(&mut conn, slot as i64, block) {
+                        log::error!("failed to persist block({slot}) {err:#?}");
+                    } else {
+                        log::info!("persisted block({slot})");
+                    }
+                }
+                Err(err) => {
+                    log::error!("failed to serialize block({slot}) {err:#?}");
                 }
             }
-            Err(err) => {
-                log::error!("failed to serialize block({slot}) {err:#?}");
-            }
+        }
+    });
+    tokio::task::spawn(async move {
+        log::info!("starting block_indexing. disable_minimization={no_minimization}");
+
+        if let Err(err) = downloader
+            .start(blocks_tx, already_indexed, start, limit, no_minimization)
+            .await
+        {
+            log::error!("downloader failed {err:#?}");
+        }
+    });
+
+    // handle exit routines
+    tokio::select! {
+        _ = sig_quit.recv() => {
+            log::warn!("goodbye..");
+            return Ok(());
+        }
+        _ = sig_int.recv() => {
+            log::warn!("goodbye..");
+            return Ok(());
+        }
+        _ = sig_term.recv() => {
+            log::warn!("goodbye..");
+            return Ok(());
         }
     }
-    Ok(())
 }

--- a/crates/sb_dl/src/commands/download.rs
+++ b/crates/sb_dl/src/commands/download.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 use clap::ArgMatches;
 use db::migrations::run_migrations;
 use sb_dl::{config::Config, Downloader};
+use serde_json::Value;
 use solana_transaction_status::UiConfirmedBlock;
 use tokio::signal::unix::{signal, SignalKind};
 
@@ -11,10 +12,18 @@ pub async fn start(matches: &ArgMatches, config_path: &str) -> anyhow::Result<()
     let start = matches.get_one::<u64>("start").cloned();
     let limit = matches.get_one::<u64>("limit").cloned();
     let no_minimization = matches.get_flag("no-minimization");
-    let downloader = Downloader::new(cfg.bigtable).await?;
+    let failed_blocks_dir = matches.get_one::<String>("failed-blocks").unwrap().clone();
+
+    // create failed blocks directory, ignoring error (its already created)
+    let _ = tokio::fs::create_dir(&failed_blocks_dir).await;
+
+    // read all failed blocks to append to the already_indexed hash set
+    //
+    // we do this so we can avoid re-downloading the blocks which are stored locally
+    let failed_blocks = read_failed_blocks(&failed_blocks_dir).await.unwrap();
 
     // load all currently indexed block number to avoid re-downloading already indexed block data
-    let already_indexed: HashSet<u64> = {
+    let mut already_indexed: HashSet<u64> = {
         let mut conn = db::new_connection(&cfg.db_url)?;
 
         // perform db migrations
@@ -28,6 +37,11 @@ pub async fn start(matches: &ArgMatches, config_path: &str) -> anyhow::Result<()
             .map(|block| block as u64)
             .collect()
     };
+
+    // mark failed blocks as already indexed to avoid redownloading
+    already_indexed.extend(failed_blocks.iter());
+
+    let downloader = Downloader::new(cfg.bigtable).await?;
 
     // receives downloaded blocks, which allows us to persist downloaded data while we download and parse other data
     let (blocks_tx, mut blocks_rx) =
@@ -46,9 +60,31 @@ pub async fn start(matches: &ArgMatches, config_path: &str) -> anyhow::Result<()
 
         while let Some((slot, block)) = blocks_rx.recv().await {
             match serde_json::to_value(block) {
-                Ok(block) => {
-                    if let Err(err) = client.insert_block(&mut conn, slot as i64, block) {
-                        log::error!("failed to persist block({slot}) {err:#?}");
+                Ok(mut block) => {
+                    if client
+                        .insert_block(&mut conn, slot as i64, block.clone())
+                        .is_err()
+                    {
+                        // block failed to be inserted into postgres
+                        // so sanitize json and persist the block on disk
+                        sanitize_value(&mut block);
+                        match serde_json::to_string(&block) {
+                            Ok(block_str) => {
+                                if let Err(err) = tokio::fs::write(
+                                    format!("{failed_blocks_dir}/block_{slot}.json"),
+                                    block_str,
+                                )
+                                .await
+                                {
+                                    log::error!("failed to store failed block({slot}) {err:#?}");
+                                } else {
+                                    log::warn!("block({slot}) failed to persist, saved to {failed_blocks_dir}/block_{slot}.json");
+                                }
+                            }
+                            Err(err) => {
+                                log::error!("failed to json serialize block({slot}) {err:#?}");
+                            }
+                        }
                     } else {
                         log::info!("persisted block({slot})");
                     }
@@ -59,6 +95,9 @@ pub async fn start(matches: &ArgMatches, config_path: &str) -> anyhow::Result<()
             }
         }
     });
+
+    let (finished_tx, finished_rx) = tokio::sync::oneshot::channel();
+
     tokio::task::spawn(async move {
         log::info!("starting block_indexing. disable_minimization={no_minimization}");
 
@@ -68,6 +107,9 @@ pub async fn start(matches: &ArgMatches, config_path: &str) -> anyhow::Result<()
         {
             log::error!("downloader failed {err:#?}");
         }
+
+        log::info!("finished downloading blocks");
+        let _ = finished_tx.send(());
     });
 
     // handle exit routines
@@ -84,5 +126,58 @@ pub async fn start(matches: &ArgMatches, config_path: &str) -> anyhow::Result<()
             log::warn!("goodbye..");
             return Ok(());
         }
+        _ = finished_rx => {
+            return Ok(());
+        }
     }
+}
+
+// sanitizes utf8 encoding issues which prevent converting serde_json::Value to a string
+fn sanitize_value(value: &mut Value) {
+    match value {
+        Value::String(s) => {
+            // Check if the string contains valid UTF-8
+            if let Err(_) = std::str::from_utf8(s.as_bytes()) {
+                // Replace invalid UTF-8 with a placeholder
+                *s = String::from_utf8_lossy(s.as_bytes()).into_owned();
+            }
+        }
+        Value::Array(arr) => {
+            for v in arr {
+                sanitize_value(v);
+            }
+        }
+        Value::Object(map) => {
+            for (_, v) in map.iter_mut() {
+                sanitize_value(v);
+            }
+        }
+        _ => {}
+    }
+}
+
+// reads all files from the failed_blocks directory, and retrieves the block numbers
+async fn read_failed_blocks(dir: &str) -> anyhow::Result<HashSet<u64>> {
+    use regex::Regex;
+    use std::collections::HashSet;
+    use std::path::Path;
+    let dir_path = Path::new(dir);
+    let mut hash_set = HashSet::new();
+    let re = Regex::new(r"block_(\d+)\.json").unwrap();
+
+    let entries = tokio::fs::read_dir(dir_path).await?;
+    tokio::pin!(entries);
+
+    while let Some(entry) = entries.next_entry().await? {
+        if let Some(file_name) = entry.file_name().to_str() {
+            if let Some(captures) = re.captures(file_name) {
+                if let Some(matched) = captures.get(1) {
+                    if let Ok(number) = matched.as_str().parse::<u64>() {
+                        hash_set.insert(number);
+                    }
+                }
+            }
+        }
+    }
+    Ok(hash_set)
 }

--- a/crates/sb_dl/src/config.rs
+++ b/crates/sb_dl/src/config.rs
@@ -16,6 +16,8 @@ pub struct BigTableConfig {
     pub instance_name: String,
     pub channel_size: usize,
     pub timeout: Duration,
+    // max decoding size in mb
+    pub max_decoding_size: usize,
 }
 
 impl Default for Config {
@@ -35,6 +37,7 @@ impl Default for BigTableConfig {
             instance_name: "solana-ledger".to_string(),
             channel_size: 10,
             timeout: Duration::from_secs(10),
+            max_decoding_size: 100*1024*1024
         }
     }
 }

--- a/crates/sb_dl/src/lib.rs
+++ b/crates/sb_dl/src/lib.rs
@@ -4,13 +4,14 @@ pub mod utils;
 use {
     anyhow::{anyhow, Context},
     bigtable_rs::{
-        bigtable::BigTableConnection,
+        bigtable::{read_rows::decode_read_rows_response, BigTableConnection},
         google::bigtable::v2::{row_filter::Filter, ReadRowsRequest, RowFilter, RowSet},
     },
     config::BigTableConfig,
     solana_sdk::clock::Slot,
     solana_storage_bigtable::{
-        bigtable::{deserialize_protobuf_or_bincode_cell_data, CellData}, key_to_slot, slot_to_blocks_key, StoredConfirmedBlock
+        bigtable::{deserialize_protobuf_or_bincode_cell_data, CellData},
+        key_to_slot, slot_to_blocks_key, StoredConfirmedBlock,
     },
     solana_storage_proto::convert::generated,
     solana_transaction_status::{ConfirmedBlock, UiConfirmedBlock},
@@ -21,6 +22,7 @@ use {
 #[derive(Clone)]
 pub struct Downloader {
     conn: BigTableConnection,
+    max_decoding_size: usize,
 }
 
 impl Downloader {
@@ -37,6 +39,7 @@ impl Downloader {
         .with_context(|| "failed to initialize bigtable connection")?;
         Ok(Self {
             conn: bigtable_conn,
+            max_decoding_size: cfg.max_decoding_size,
         })
     }
     /// Starts the bigtable downloader
@@ -79,22 +82,21 @@ impl Downloader {
             })
             .collect::<Vec<solana_program::clock::Slot>>();
 
-
         for slot in slots_to_fetch {
-
             // retrieve confirmed block from bigtable
             match self.get_confirmed_block(slot).await {
                 Ok(block) => {
-
-                    // post process the block to handle encoding and space minimization
-                    match process_block(block, no_minimization) {
-                        Ok(block) => {
-                            if let Err(err) = blocks_tx.send((slot, block)).await {
-                                log::error!("failed to send block({slot}) {err:#?}");
+                    if let Some(block) = block {
+                        // post process the block to handle encoding and space minimization
+                        match process_block(block, no_minimization) {
+                            Ok(block) => {
+                                if let Err(err) = blocks_tx.send((slot, block)).await {
+                                    log::error!("failed to send block({slot}) {err:#?}");
+                                }
                             }
-                        }
-                        Err(err) => {
-                            log::error!("failed to minimize and encode block({slot}) {err:#?}");
+                            Err(err) => {
+                                log::error!("failed to minimize and encode block({slot}) {err:#?}");
+                            }
                         }
                     }
                 }
@@ -107,35 +109,43 @@ impl Downloader {
         Ok(())
     }
 
-    pub async fn get_confirmed_block(&self, slot: Slot) -> anyhow::Result<ConfirmedBlock> {
+    pub async fn get_confirmed_block(&self, slot: Slot) -> anyhow::Result<Option<ConfirmedBlock>> {
         let mut client = self.conn.client();
 
-        let mut response = client
-            .read_rows(ReadRowsRequest {
-                table_name: client.get_full_table_name("blocks"),
-                app_profile_id: "default".to_string(),
-                rows_limit: 1,
-                rows: Some(RowSet {
-                    row_keys: vec![slot_to_blocks_key(slot).into()],
-                    row_ranges: vec![],
-                }),
-                filter: Some(RowFilter {
-                    // Only return the latest version of each cell
-                    filter: Some(Filter::CellsPerColumnLimitFilter(1)),
-                }),
-                request_stats_view: 0,
-                reversed: false,
-            })
-            .await
-            .with_context(|| format!("failed to get block for slot({slot})"))?;
-        
+        let mut big_client = client
+            .get_client()
+            .clone()
+            .max_decoding_message_size(self.max_decoding_size);
+
+        let mut response = decode_read_rows_response(
+            &None,
+            big_client
+                .read_rows(ReadRowsRequest {
+                    table_name: client.get_full_table_name("blocks"),
+                    app_profile_id: "default".to_string(),
+                    rows_limit: 1,
+                    rows: Some(RowSet {
+                        row_keys: vec![slot_to_blocks_key(slot).into()],
+                        row_ranges: vec![],
+                    }),
+                    filter: Some(RowFilter {
+                        // Only return the latest version of each cell
+                        filter: Some(Filter::CellsPerColumnLimitFilter(1)),
+                    }),
+                    request_stats_view: 0,
+                    reversed: false,
+                })
+                .await
+                .with_context(|| format!("failed to get block for slot({slot})"))?
+                .into_inner(),
+        )
+        .await
+        .with_context(|| "failed to decode response")?;
+    
         // ensure we got a single response, as we requested 1 slot
         if response.len() != 1 {
-            return Err(anyhow!(
-                "mismatched response length. got {}, want {}",
-                response.len(),
-                1
-            ));
+            // block does not exist and cant be found
+            return Ok(None);
         }
 
         // ensure the cell contains some data
@@ -155,10 +165,10 @@ impl Downloader {
         match key_to_slot(&key) {
             Some(keyed_slot) => {
                 if keyed_slot != slot {
-                    return Err(anyhow!("keyed_slot({keyed_slot}) != slot({slot}"))
+                    return Err(anyhow!("keyed_slot({keyed_slot}) != slot({slot}"));
                 }
             }
-            None => return Err(anyhow!("failed to parse key to slot({slot})"))
+            None => return Err(anyhow!("failed to parse key to slot({slot})")),
         }
 
         if response[0].1[0].qualifier.is_empty() {
@@ -193,6 +203,6 @@ impl Downloader {
                 }
             },
         };
-        Ok(confirmed_block)
+        Ok(Some(confirmed_block))
     }
 }

--- a/crates/sb_dl/src/main.rs
+++ b/crates/sb_dl/src/main.rs
@@ -49,6 +49,13 @@ async fn main() -> Result<()> {
                         .action(clap::ArgAction::SetTrue)
                         .default_value("false")
                         .required(false),
+                )
+                .arg(
+                    Arg::new("failed-blocks")
+                    .long("failed-blocks")
+                    .help("directory to store failed blocks in")
+                    .default_value("failed_blocks")
+                    .required(false)
                 ),
             Command::new("new-config"),
         ])


### PR DESCRIPTION
# Overview

* Allows setting max decoding size to work around large messages
* When a failure to persist block happens due to unicode issues persist the block locally for manual remediation
* Make block downloading, and block persistence two concurrent tasks

# Unicode Issues

After ui encoding a block, it appears that occasionally we are unable to insert the block into postgres after serializing to a `serde_json::Value` object with a column type of `JSONB`. As a short term work around any blocks this happens for have their JSON string values sanitized, converted to a string, and then saved on disk.