### PR TITLE
Recent Block Backfiller

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -29,6 +29,12 @@
         dest: "/etc/systemd/system/bigtable_downloader.service"
         mode: 0755
 
+    - name: Ship backfiller service to server
+      template:
+        src: "backfiller.service.j2"
+        dest: "/etc/systemd/system/backfiller.service"
+        mode: 0755
+
     - name: Configuring geyser stream service
       service:
         name: geyser_stream
@@ -39,6 +45,13 @@
     - name: Configuring bigtable downloader service
       service:
         name: bigtable_downloader
+        state: stopped
+        enabled: false
+        daemon_reload: true
+
+    - name: Configuring backfiller service
+      service:
+        name: backfiller
         state: restarted
         enabled: true
         daemon_reload: true

--- a/ansible/templates/backfiller.service.j2
+++ b/ansible/templates/backfiller.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=block backfiller service
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart={{ app_root }}/sb_dl --log-file {{ app_root }}/sb_dl_geyser.log --config {{ app_root }}/config.yaml backfiller --failed-blocks {{ app_root }}/failed_blocks
+
+# Restart every >2 seconds to avoid StartLimitInterval failure
+RestartSec=30
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/templates/backfiller.service.j2
+++ b/ansible/templates/backfiller.service.j2
@@ -4,7 +4,7 @@ After=network-online.target
 
 [Service]
 Type=simple
-ExecStart={{ app_root }}/sb_dl --log-file {{ app_root }}/sb_dl_geyser.log --config {{ app_root }}/config.yaml backfiller --failed-blocks {{ app_root }}/failed_blocks
+ExecStart={{ app_root }}/sb_dl --config {{ app_root }}/config.yaml backfiller --failed-blocks {{ app_root }}/failed_blocks
 
 # Restart every >2 seconds to avoid StartLimitInterval failure
 RestartSec=30

--- a/crates/db/src/models.rs
+++ b/crates/db/src/models.rs
@@ -1,6 +1,6 @@
 use {diesel::prelude::*, uuid::Uuid};
 
-#[derive(Queryable, AsChangeset, Identifiable, Debug, Clone)]
+#[derive(Queryable, AsChangeset, Identifiable, Debug, Clone, Selectable)]
 #[diesel(table_name = super::schema::blocks)]
 pub struct Blocks {
     pub id: Uuid,

--- a/crates/sb_dl/src/backfill.rs
+++ b/crates/sb_dl/src/backfill.rs
@@ -1,0 +1,63 @@
+use std::time::Duration;
+
+use anyhow::Context;
+use solana_client::{nonblocking::rpc_client::RpcClient, rpc_config::RpcBlockConfig};
+use solana_sdk::commitment_config::CommitmentConfig;
+use solana_transaction_status::{TransactionDetails, UiConfirmedBlock, UiTransactionEncoding};
+
+use crate::utils::{filter_vote_transactions, process_block};
+
+pub struct Backfiller {
+    rpc: RpcClient,
+}
+
+impl Backfiller {
+    pub fn new(endpoint: &str) -> Self {
+        Self {
+            rpc: RpcClient::new(endpoint.to_string()),
+        }
+    }
+    pub async fn start(
+        &self,
+        blocks_tx: tokio::sync::mpsc::Sender<(u64, UiConfirmedBlock)>,
+        no_minimization: bool,
+    ) -> anyhow::Result<()> {
+        loop {
+            let current_height = self
+                .rpc
+                .get_block_height()
+                .await
+                .with_context(|| "failed to get block height")?;
+            // backfill 300 most recent blocks, over estimating blocks per second by 2x
+            for block_height in (current_height - 300..current_height) {
+                match self
+                    .rpc
+                    .get_block_with_config(
+                        block_height,
+                        RpcBlockConfig {
+                            encoding: Some(UiTransactionEncoding::JsonParsed),
+                            transaction_details: Some(TransactionDetails::Full),
+                            rewards: Some(false),
+                            commitment: Some(CommitmentConfig::finalized()),
+                            max_supported_transaction_version: Some(1),
+                        },
+                    )
+                    .await
+                {
+                    Ok(mut block) => {
+                        if no_minimization == false {
+                            block = filter_vote_transactions(block);
+                        }
+                        if let Err(err) = blocks_tx.send((block_height, block)).await {
+                            log::error!("failed to notify block {err:#?}");
+                        }
+                    }
+                    Err(err) => {
+                        log::error!("failed to retrieve block({block_height}) {err:#?}");
+                    }
+                }
+            }
+            tokio::time::sleep(Duration::from_secs(60)).await;
+        }
+    }
+}

--- a/crates/sb_dl/src/commands/download.rs
+++ b/crates/sb_dl/src/commands/download.rs
@@ -288,27 +288,37 @@ async fn block_persistence_loop(
     while let Some((slot, block)) = blocks_rx.recv().await {
         match serde_json::to_value(block) {
             Ok(mut block) => {
-                if let Err(err) = client.insert_block(&mut conn, slot as i64, block.clone()) {
-                    log::error!("block({slot}) persistence failed {err:#?}");
-                    // block failed to be inserted into postgres
-                    // so sanitize json and persist the block on disk
+                if client
+                    .insert_block(&mut conn, slot as i64, block.clone())
+                    .is_err()
+                {
+                    log::warn!("block({slot}) persistence failed, retrying with sanitization");
+                    // escape invalid unicode points
                     sanitize_value(&mut block);
-                    match serde_json::to_string(&block) {
-                        Ok(block_str) => {
-                            if let Err(err) = tokio::fs::write(
-                                format!("{failed_blocks_dir}/block_{slot}.json"),
-                                block_str,
-                            )
-                            .await
-                            {
-                                log::error!("failed to store failed block({slot}) {err:#?}");
-                            } else {
-                                log::warn!("block({slot}) failed to persist, saved to {failed_blocks_dir}/block_{slot}.json");
+                    // replace escaped unicode points with empty string
+                    sanitize_for_postgres(&mut block);
+                    // try to reinsert block
+                    if let Err(err) = client.insert_block(&mut conn, slot as i64, block.clone()) {
+                        log::error!("block({slot}) retry failed {err:#?}");
+                        match serde_json::to_string(&block) {
+                            Ok(block_str) => {
+                                if let Err(err) = tokio::fs::write(
+                                    format!("{failed_blocks_dir}/block_{slot}.json"),
+                                    block_str,
+                                )
+                                .await
+                                {
+                                    log::error!("failed to store failed block({slot}) {err:#?}");
+                                } else {
+                                    log::warn!("block({slot}) failed to persist, saved to {failed_blocks_dir}/block_{slot}.json");
+                                }
+                            }
+                            Err(err) => {
+                                log::error!("failed to serialize block({slot}) {err:#?}");
                             }
                         }
-                        Err(err) => {
-                            log::error!("failed to json serialize block({slot}) {err:#?}");
-                        }
+                    } else {
+                        log::info!("block({slot}) persisted after sanitization");
                     }
                 } else {
                     log::info!("persisted block({slot})");

--- a/crates/sb_dl/src/commands/download.rs
+++ b/crates/sb_dl/src/commands/download.rs
@@ -1,14 +1,16 @@
-use std::collections::HashSet;
-
-use anyhow::anyhow;
-use clap::ArgMatches;
-use db::migrations::run_migrations;
-use sb_dl::{
-    config::{self, Config}, geyser::{new_geyser_client, subscribe_blocks}, bigtable::Downloader
+use {
+    super::utils::{get_failed_blocks, load_failed_blocks, sanitize_for_postgres, sanitize_value},
+    anyhow::anyhow,
+    clap::ArgMatches,
+    db::migrations::run_migrations,
+    diesel::PgConnection,
+    sb_dl::{
+        backfill::Backfiller, bigtable::Downloader, config::Config, geyser::{new_geyser_client, subscribe_blocks}
+    },
+    solana_transaction_status::UiConfirmedBlock,
+    std::collections::HashSet,
+    tokio::signal::unix::{signal, SignalKind},
 };
-use serde_json::Value;
-use solana_transaction_status::UiConfirmedBlock;
-use tokio::signal::unix::{signal, SignalKind};
 
 pub async fn start(matches: &ArgMatches, config_path: &str) -> anyhow::Result<()> {
     let cfg = Config::load(config_path).await?;
@@ -47,7 +49,7 @@ pub async fn start(matches: &ArgMatches, config_path: &str) -> anyhow::Result<()
     let downloader = Downloader::new(cfg.bigtable).await?;
 
     // receives downloaded blocks, which allows us to persist downloaded data while we download and parse other data
-    let (blocks_tx, mut blocks_rx) =
+    let (blocks_tx, blocks_rx) =
         tokio::sync::mpsc::channel::<(u64, UiConfirmedBlock)>(limit.unwrap_or(1_000) as usize);
 
     let mut sig_quit = signal(SignalKind::quit())?;
@@ -55,49 +57,12 @@ pub async fn start(matches: &ArgMatches, config_path: &str) -> anyhow::Result<()
     let mut sig_term = signal(SignalKind::terminate())?;
 
     // if we fail to connect to postgres, we should terminate the thread
-    let mut conn = db::new_connection(&cfg.db_url)?;
+    let conn = db::new_connection(&cfg.db_url)?;
 
     // start the background persistence task
-    tokio::task::spawn(async move {
-        let client = db::client::Client {};
-
-        while let Some((slot, block)) = blocks_rx.recv().await {
-            match serde_json::to_value(block) {
-                Ok(mut block) => {
-                    if client
-                        .insert_block(&mut conn, slot as i64, block.clone())
-                        .is_err()
-                    {
-                        // block failed to be inserted into postgres
-                        // so sanitize json and persist the block on disk
-                        sanitize_value(&mut block);
-                        match serde_json::to_string(&block) {
-                            Ok(block_str) => {
-                                if let Err(err) = tokio::fs::write(
-                                    format!("{failed_blocks_dir}/block_{slot}.json"),
-                                    block_str,
-                                )
-                                .await
-                                {
-                                    log::error!("failed to store failed block({slot}) {err:#?}");
-                                } else {
-                                    log::warn!("block({slot}) failed to persist, saved to {failed_blocks_dir}/block_{slot}.json");
-                                }
-                            }
-                            Err(err) => {
-                                log::error!("failed to json serialize block({slot}) {err:#?}");
-                            }
-                        }
-                    } else {
-                        log::info!("persisted block({slot})");
-                    }
-                }
-                Err(err) => {
-                    log::error!("failed to serialize block({slot}) {err:#?}");
-                }
-            }
-        }
-    });
+    tokio::task::spawn(
+        async move { block_persistence_loop(conn, failed_blocks_dir, blocks_rx).await },
+    );
 
     let (finished_tx, finished_rx) = tokio::sync::oneshot::channel();
 
@@ -150,77 +115,36 @@ pub async fn stream_geyser_blocks(matches: &ArgMatches, config_path: &str) -> an
         // perform db migrations
         run_migrations(&mut conn);
     }
-    
+
     let gc = new_geyser_client(
         &cfg.geyser.endpoint,
         &cfg.geyser.token,
         cfg.geyser.max_decoding_size,
-        cfg.geyser.max_encoding_size
-    ).await?;
+        cfg.geyser.max_encoding_size,
+    )
+    .await?;
 
     // receives downloaded blocks, which allows us to persist downloaded data while we download and parse other data
-    let (blocks_tx, mut blocks_rx) =
-        tokio::sync::mpsc::channel::<(u64, UiConfirmedBlock)>(1000);
+    let (blocks_tx, blocks_rx) = tokio::sync::mpsc::channel::<(u64, UiConfirmedBlock)>(1000);
 
     let mut sig_quit = signal(SignalKind::quit())?;
     let mut sig_int = signal(SignalKind::interrupt())?;
     let mut sig_term = signal(SignalKind::terminate())?;
 
     // if we fail to connect to postgres, we should terminate the thread
-    let mut conn = db::new_connection(&cfg.db_url)?;
+    let conn = db::new_connection(&cfg.db_url)?;
 
     // start the background persistence task
-    tokio::task::spawn(async move {
-        let client = db::client::Client {};
-
-        while let Some((slot, block)) = blocks_rx.recv().await {
-            match serde_json::to_value(block) {
-                Ok(mut block) => {
-                    if let Err(err) = client
-                        .insert_block(&mut conn, slot as i64, block.clone())
-                    {
-                        log::error!("block persistence failed {err:#?}");
-                        // block failed to be inserted into postgres
-                        // so sanitize json and persist the block on disk
-                        sanitize_value(&mut block);
-                        match serde_json::to_string(&block) {
-                            Ok(block_str) => {
-                                if let Err(err) = tokio::fs::write(
-                                    format!("{failed_blocks_dir}/block_{slot}.json"),
-                                    block_str,
-                                )
-                                .await
-                                {
-                                    log::error!("failed to store failed block({slot}) {err:#?}");
-                                } else {
-                                    log::warn!("block({slot}) failed to persist, saved to {failed_blocks_dir}/block_{slot}.json");
-                                }
-                            }
-                            Err(err) => {
-                                log::error!("failed to json serialize block({slot}) {err:#?}");
-                            }
-                        }
-                    } else {
-                        log::info!("persisted block({slot})");
-                    }
-                }
-                Err(err) => {
-                    log::error!("failed to serialize block({slot}) {err:#?}");
-                }
-            }
-        }
-    });
+    tokio::task::spawn(
+        async move { block_persistence_loop(conn, failed_blocks_dir, blocks_rx).await },
+    );
 
     // optional value containing error message encountered during program execution
     let (finished_tx, finished_rx) = tokio::sync::oneshot::channel::<Option<String>>();
 
     tokio::task::spawn(async move {
         log::info!("starting geyser stream. disable_minimization={no_minimization}");
-        if let Err(err) = subscribe_blocks(
-            gc,
-            blocks_tx,
-            no_minimization
-        ).await {
+        if let Err(err) = subscribe_blocks(gc, blocks_tx, no_minimization).await {
             let _ = finished_tx.send(Some(format!("geyser stream failed {err:#?}")));
         } else {
             log::info!("geyser stream finished");
@@ -255,97 +179,144 @@ pub async fn stream_geyser_blocks(matches: &ArgMatches, config_path: &str) -> an
     }
 }
 
+pub async fn recent_backfill(matches: &ArgMatches, config_path: &str) -> anyhow::Result<()> {
+    let cfg = Config::load(config_path).await?;
+    let failed_blocks_dir = matches.get_one::<String>("failed-blocks").unwrap().clone();
+
+    // create failed blocks directory, ignoring error (its already created)
+    let _ = tokio::fs::create_dir(&failed_blocks_dir).await;
+
+    let no_minimization = matches.get_flag("no-minimization");
+
+    // receives downloaded blocks, which allows us to persist downloaded data while we download and parse other data
+    let (blocks_tx, blocks_rx) = tokio::sync::mpsc::channel::<(u64, UiConfirmedBlock)>(1000);
+
+    let mut sig_quit = signal(SignalKind::quit())?;
+    let mut sig_int = signal(SignalKind::interrupt())?;
+    let mut sig_term = signal(SignalKind::terminate())?;
+
+    // if we fail to connect to postgres, we should terminate the thread
+    let conn = db::new_connection(&cfg.db_url)?;
+
+    // start the background persistence task
+    tokio::task::spawn(
+        async move { block_persistence_loop(conn, failed_blocks_dir, blocks_rx).await },
+    );
+
+    let backfiller = Backfiller::new(&cfg.rpc_url);
+
+    let (finished_tx, finished_rx) = tokio::sync::oneshot::channel();
+
+    tokio::task::spawn(async move {
+        log::info!("starting backfiller. disable_minimization={no_minimization}");
+        if let Err(err) = backfiller.start(
+            blocks_tx,
+            no_minimization
+        ).await {
+            log::error!("backfiller failed {err:#?}");
+        }
+        log::info!("backfiller finished");
+        let _ = finished_tx.send(());
+    });
+
+    // handle exit routines
+    tokio::select! {
+        _ = sig_quit.recv() => {
+            log::warn!("goodbye..");
+            return Ok(());
+        }
+        _ = sig_int.recv() => {
+            log::warn!("goodbye..");
+            return Ok(());
+        }
+        _ = sig_term.recv() => {
+            log::warn!("goodbye..");
+            return Ok(());
+        }
+        _ = finished_rx => {
+            return Ok(());
+        }
+    }
+}
 
 pub async fn import_failed_blocks(matches: &ArgMatches, config_path: &str) -> anyhow::Result<()> {
     let cfg = Config::load(config_path).await?;
     let failed_blocks_dir = matches.get_one::<String>("failed-blocks").unwrap().clone();
-    let failed_blocks = load_failed_blocks(&failed_blocks_dir).await?;
+
+    let (blocks_tx, mut blocks_rx) = tokio::sync::mpsc::channel::<(u64, serde_json::Value)>(1000);
 
     // if we fail to connect to postgres, we should terminate the thread
     let mut conn = db::new_connection(&cfg.db_url)?;
 
-    let client = db::client::Client {};
-
-    for (slot, block) in failed_blocks {
-        if let Err(err) = client.insert_block(&mut conn, slot as i64, block) {
-            log::error!("failed to insert block({slot}) {err:#?}");
-        }
+    let (finished_tx, finished_rx) = tokio::sync::oneshot::channel();
+    {
+        let failed_blocks_dir = failed_blocks_dir.clone();
+        tokio::task::spawn(async move {
+            let client = db::client::Client {};
+    
+            while let Some((slot, mut block)) = blocks_rx.recv().await {
+                sanitize_for_postgres(&mut block);
+                if let Err(err) = client.insert_block(&mut conn, slot as i64, block) {
+                    log::error!("failed to insert block({slot}) {err:#?}");
+                } else {
+                    log::info!("inserted block({slot})");
+                    if let Err(err) = tokio::fs::remove_file(format!("{failed_blocks_dir}/block_{slot}.json")).await {
+                        log::error!("failed to remove persisted block({slot}) {err:#?}");
+                    }
+                }
+            }
+    
+            let _ = finished_tx.send(());
+        });
     }
+
+
+    load_failed_blocks(&failed_blocks_dir, blocks_tx).await?;
+
+    let _ = finished_rx.await;
 
     Ok(())
 }
 
-// sanitizes utf8 encoding issues which prevent converting serde_json::Value to a string
-fn sanitize_value(value: &mut Value) {
-    match value {
-        Value::String(s) => {
-            // Check if the string contains valid UTF-8
-            if let Err(_) = std::str::from_utf8(s.as_bytes()) {
-                // Replace invalid UTF-8 with a placeholder
-                *s = String::from_utf8_lossy(s.as_bytes()).into_owned();
-            }
-        }
-        Value::Array(arr) => {
-            for v in arr {
-                sanitize_value(v);
-            }
-        }
-        Value::Object(map) => {
-            for (_, v) in map.iter_mut() {
-                sanitize_value(v);
-            }
-        }
-        _ => {}
-    }
-}
+async fn block_persistence_loop(
+    mut conn: PgConnection,
+    failed_blocks_dir: String,
+    mut blocks_rx: tokio::sync::mpsc::Receiver<(u64, UiConfirmedBlock)>,
+) {
+    let client = db::client::Client {};
 
-// reads all files from the failed_blocks directory, and retrieves the block numbers
-async fn get_failed_blocks(dir: &str) -> anyhow::Result<HashSet<u64>> {
-    use regex::Regex;
-    use std::collections::HashSet;
-    use std::path::Path;
-    let dir_path = Path::new(dir);
-    let re = Regex::new(r"block_(\d+)\.json").unwrap();
-    let mut hash_set = HashSet::new();
-
-    let entries = tokio::fs::read_dir(dir_path).await?;
-    tokio::pin!(entries);
-
-    while let Some(entry) = entries.next_entry().await? {
-        if let Some(file_name) = entry.file_name().to_str() {
-            if let Some(captures) = re.captures(file_name) {
-                if let Some(matched) = captures.get(1) {
-                    if let Ok(number) = matched.as_str().parse::<u64>() {
-                        hash_set.insert(number);
+    while let Some((slot, block)) = blocks_rx.recv().await {
+        match serde_json::to_value(block) {
+            Ok(mut block) => {
+                if let Err(err) = client.insert_block(&mut conn, slot as i64, block.clone()) {
+                    log::error!("block({slot}) persistence failed {err:#?}");
+                    // block failed to be inserted into postgres
+                    // so sanitize json and persist the block on disk
+                    sanitize_value(&mut block);
+                    match serde_json::to_string(&block) {
+                        Ok(block_str) => {
+                            if let Err(err) = tokio::fs::write(
+                                format!("{failed_blocks_dir}/block_{slot}.json"),
+                                block_str,
+                            )
+                            .await
+                            {
+                                log::error!("failed to store failed block({slot}) {err:#?}");
+                            } else {
+                                log::warn!("block({slot}) failed to persist, saved to {failed_blocks_dir}/block_{slot}.json");
+                            }
+                        }
+                        Err(err) => {
+                            log::error!("failed to json serialize block({slot}) {err:#?}");
+                        }
                     }
+                } else {
+                    log::info!("persisted block({slot})");
                 }
             }
-        }
-    }
-    Ok(hash_set)
-}
-
-async fn load_failed_blocks(dir: &str) -> anyhow::Result<Vec<(u64, serde_json::Value)>> {
-    use regex::Regex;
-
-    let mut blocks = vec![];
-
-    let re = Regex::new(r"block_(\d+)\.json").unwrap();
-    let entries = tokio::fs::read_dir(dir).await?;
-    tokio::pin!(entries);
-
-    while let Some(entry) = entries.next_entry().await? {
-        if let Some(file_name) = entry.file_name().to_str() {
-            if let Some(captures) = re.captures(file_name) {
-                if let Some(matched) = captures.get(1) {
-                    if let Ok(slot) = matched.as_str().parse::<u64>() {
-                        let block = tokio::fs::read_to_string(entry.path()).await?;
-                        let block: serde_json::Value = serde_json::from_str(&block)?;
-                        blocks.push((slot, block));
-                    }
-                }
+            Err(err) => {
+                log::error!("failed to serialize block({slot}) {err:#?}");
             }
         }
     }
-    Ok(blocks)
 }

--- a/crates/sb_dl/src/commands/mod.rs
+++ b/crates/sb_dl/src/commands/mod.rs
@@ -2,3 +2,4 @@ pub mod config;
 pub mod download;
 pub mod idl_indexer;
 pub mod program_indexer;
+pub mod utils;

--- a/crates/sb_dl/src/commands/utils.rs
+++ b/crates/sb_dl/src/commands/utils.rs
@@ -1,0 +1,103 @@
+use std::collections::HashSet;
+
+use serde_json::Value;
+
+
+// sanitizes utf8 encoding issues which prevent converting serde_json::Value to a string
+// this is done before failed blocks are persisted to disk
+pub fn sanitize_value(value: &mut Value) {
+    match value {
+        Value::String(s) => {
+            // Check if the string contains valid UTF-8
+            if let Err(_) = std::str::from_utf8(s.as_bytes()) {
+                // Replace invalid UTF-8 with a placeholder
+                *s = String::from_utf8_lossy(s.as_bytes()).into_owned();
+            }
+        }
+        Value::Array(arr) => {
+            for v in arr {
+                sanitize_value(v);
+            }
+        }
+        Value::Object(map) => {
+            for (_, v) in map.iter_mut() {
+                sanitize_value(v);
+            }
+        }
+        _ => {}
+    }
+}
+
+// reads all files from the failed_blocks directory, and retrieves the block numbers
+pub async fn get_failed_blocks(dir: &str) -> anyhow::Result<HashSet<u64>> {
+    use regex::Regex;
+    use std::collections::HashSet;
+    use std::path::Path;
+    let dir_path = Path::new(dir);
+    let re = Regex::new(r"block_(\d+)\.json").unwrap();
+    let mut hash_set = HashSet::new();
+
+    let entries = tokio::fs::read_dir(dir_path).await?;
+    tokio::pin!(entries);
+
+    while let Some(entry) = entries.next_entry().await? {
+        if let Some(file_name) = entry.file_name().to_str() {
+            if let Some(captures) = re.captures(file_name) {
+                if let Some(matched) = captures.get(1) {
+                    if let Ok(number) = matched.as_str().parse::<u64>() {
+                        hash_set.insert(number);
+                    }
+                }
+            }
+        }
+    }
+    Ok(hash_set)
+}
+
+pub async fn load_failed_blocks(
+    dir: &str, 
+    blocks_tx: tokio::sync::mpsc::Sender<(u64, serde_json::Value)>,
+) -> anyhow::Result<()> {
+    use regex::Regex;
+
+    let re = Regex::new(r"block_(\d+)\.json").unwrap();
+    let entries = tokio::fs::read_dir(dir).await?;
+    tokio::pin!(entries);
+
+    while let Some(entry) = entries.next_entry().await? {
+        if let Some(file_name) = entry.file_name().to_str() {
+            if let Some(captures) = re.captures(file_name) {
+                if let Some(matched) = captures.get(1) {
+                    if let Ok(slot) = matched.as_str().parse::<u64>() {
+                        let block = tokio::fs::read_to_string(entry.path()).await?;
+                        let block: serde_json::Value = serde_json::from_str(&block)?;
+                        if let Err(err) = blocks_tx.send((slot, block)).await {
+                            log::error!("failed to notify block({slot}) {err:#?}");
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn sanitize_for_postgres(value: &mut Value) {
+    match value {
+        Value::String(ref mut s) => {
+            *s = s.replace("\u{0000}", "");
+
+        }
+        Value::Array(ref mut arr) => {
+            for item in arr {
+                sanitize_for_postgres(item);
+            }
+        }
+        Value::Object(ref mut obj) => {
+            for (_key, val) in obj.iter_mut() {
+                sanitize_for_postgres(val);
+            }
+        }
+        _ => {}
+    }
+}

--- a/crates/sb_dl/src/lib.rs
+++ b/crates/sb_dl/src/lib.rs
@@ -4,4 +4,5 @@ pub mod geyser;
 pub mod idl;
 pub mod programs;
 pub mod bigtable;
+pub mod backfill;
 

--- a/crates/sb_dl/src/main.rs
+++ b/crates/sb_dl/src/main.rs
@@ -90,7 +90,14 @@ async fn main() -> Result<()> {
     let config_path = matches.get_one::<String>("config").unwrap();
     let log_level = matches.get_one::<String>("log-level").unwrap();
     let log_file = matches.get_one::<String>("log-file").unwrap();
-
+    // only preserve logs file the single most recent execution of the service
+    if let Ok(exists) = tokio::fs::try_exists(log_file).await {
+        if exists {
+            if let Err(err) = tokio::fs::rename(log_file, format!("{log_file}.old")).await {
+                log::error!("failed to rotate log file {err:#?}");
+            }
+        }
+    }
     init_log(log_level, log_file);
 
     process_matches(&matches, config_path).await

--- a/crates/sb_dl/src/main.rs
+++ b/crates/sb_dl/src/main.rs
@@ -82,6 +82,23 @@ async fn main() -> Result<()> {
                 .default_value("failed_blocks")
                 .required(false)
             ),
+            Command::new("backfiller")
+            .about("block backfiller to covers gaps missed by geyser")
+            .arg(
+                Arg::new("no-minimization")
+                    .long("no-minimization")
+                    .help("if present, disable block minimization")
+                    .action(clap::ArgAction::SetTrue)
+                    .default_value("false")
+                    .required(false),
+            )
+            .arg(
+                Arg::new("failed-blocks")
+                .long("failed-blocks")
+                .help("directory to store failed blocks in")
+                .default_value("failed_blocks")
+                .required(false)
+            ),
             Command::new("index-idls"),
             Command::new("index-programs"),
         ])
@@ -109,6 +126,7 @@ async fn process_matches(matches: &ArgMatches, config_path: &str) -> anyhow::Res
         Some(("import-failed-blocks", ifb)) => commands::download::import_failed_blocks(ifb, config_path).await,
         Some(("new-config", _)) => commands::config::new_config(config_path).await,
         Some(("geyser-stream", gs)) => commands::download::stream_geyser_blocks(gs, config_path).await,
+        Some(("backfiller", bf)) => commands::download::recent_backfill(bf, config_path).await,
         Some(("index-idls", _)) => commands::idl_indexer::index_idls(config_path).await,
         Some(("index-programs", _)) => commands::program_indexer::index_programs(config_path).await,
         _ => Err(anyhow!("invalid subcommand")),

--- a/scripts/failed_blocks_import.sh
+++ b/scripts/failed_blocks_import.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+./sb_dl import-failed-blocks --failed-blocks failed_blocks

--- a/scripts/program_index.sh
+++ b/scripts/program_index.sh
@@ -3,5 +3,5 @@
 # indexes programs, followed by idl indexing
 # should be called as a cronjob
 
-sb_dl index-programs
-sb_dl index-idls
+./sb_dl index-programs
+./sb_dl index-idls


### PR DESCRIPTION
# Overview

* Adds a recent block backfiller service that manually queries RPC for 300 most recent blocks to fill any potential gaps from geyser stream failures
* When block persistence fails, retry with sanitization. If that fails persist block to disk for manual recovery
* Basic log file rotation
* Bubble geyser stream errors up to the executable to allow for systemd automatic service restarts on failure
* Cleanup download command functions