### PR TITLE
Transfer Flow API Updates

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -35,6 +35,12 @@
         dest: "/etc/systemd/system/backfiller.service"
         mode: 0755
 
+    - name: Ship transfer flow api service to server
+      template:
+        src: "transfer_flow_api.service.j2"
+        dest: "/etc/systemd/system/transfer_flow_api.service"
+        mode: 0755
+
     - name: Configuring geyser stream service
       service:
         name: geyser_stream
@@ -52,6 +58,13 @@
     - name: Configuring backfiller service
       service:
         name: backfiller
+        state: restarted
+        enabled: true
+        daemon_reload: true
+
+    - name: Configuring transfer flow api service
+      service:
+        name: transfer_flow_api
         state: restarted
         enabled: true
         daemon_reload: true

--- a/ansible/templates/transfer_flow_api.service.j2
+++ b/ansible/templates/transfer_flow_api.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=transfer flow api service
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart={{ app_root }}/sb_dl --log-file {{ app_root }}/logs/sb_dl_transfer_flow_api.log --config {{ app_root }}/config.yaml services transfer-flow-api --listen-url 0.0.0.0:8081
+
+# Restart every >2 seconds to avoid StartLimitInterval failure
+RestartSec=30
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/crates/sb_dl/Cargo.toml
+++ b/crates/sb_dl/Cargo.toml
@@ -77,7 +77,8 @@ version = "1"
 version = "0.6"
 [dependencies.axum]
 version = "0.7"
-
+[dependencies.chrono]
+version = "0.4"
 [dependencies.db]
 path = "../db"
 [dependencies.solana-storage-bigtable]

--- a/crates/sb_dl/src/parsable_instructions.rs
+++ b/crates/sb_dl/src/parsable_instructions.rs
@@ -200,7 +200,8 @@ pub mod token {
         TransferChecked(TransferChecked),
         MintToChecked(MintToChecked),
         BurnChecked(BurnChecked),
-        CloseAccount(CloseAccount),
+        // temporarily omit instruction until account closure is fully supported
+        //CloseAccount(CloseAccount),
     }
 
     #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -293,11 +294,11 @@ pub mod token {
             Ok(Some(TokenInstructions::BurnChecked(
                 serde_json::from_value(partially_decoded.info)?,
             )))
-        } else if CLOSE_ACCOUNT.eq(ix_type) {
+        } /*else if CLOSE_ACCOUNT.eq(ix_type) {
             Ok(Some(TokenInstructions::CloseAccount(
                 serde_json::from_value(partially_decoded.info)?,
             )))
-        } else {
+        } */else {
             return Ok(None);
         }
     }

--- a/crates/sb_dl/src/transfer_flow/types.rs
+++ b/crates/sb_dl/src/transfer_flow/types.rs
@@ -120,6 +120,7 @@ impl From<DecodedInstruction> for Transfer {
                     mint: tx.mint,
                     amount: tx.token_amount.amount,
                 },
+                /* temporarily omit until account closure is fully supported
                 TokenInstructions::CloseAccount(tx) => Transfer {
                     // should we use owner here instead?
                     sender: tx.account,
@@ -129,7 +130,7 @@ impl From<DecodedInstruction> for Transfer {
                     // todo: need to figure out the way to handle this when the token account is for wsol
                     // for non wsol accounts this will just be the rent
                     amount: tx.amount.unwrap_or_default(),
-                },
+                },*/
             },
         }
     }


### PR DESCRIPTION
# Overview

* Add ansible service for transfer flow api
* When requesting flows from the api, use blocks not slots
* Add time, and slot fields to the api response
* Temporarily ignore `TokenInstructions::CloseAccount` until it is fully supported