### PR TITLE
Invalid Slot Repair Command

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -41,6 +41,18 @@
         dest: "/etc/systemd/system/transfer_flow_api.service"
         mode: 0755
 
+    - name: Ship gap fill script to server
+      template:
+        src: "gap_fill.sh.j2"
+        dest: "{{app_root}}/gap_fill.sh"
+        mode: 0755
+
+    - name: Ship gap fill service to server
+      template:
+        src: "gap_fill.service.j2"
+        dest: "/etc/systemd/system/gap_fill.service"
+        mode: 0755
+
     - name: Configuring geyser stream service
       service:
         name: geyser_stream
@@ -65,6 +77,13 @@
     - name: Configuring transfer flow api service
       service:
         name: transfer_flow_api
+        state: restarted
+        enabled: true
+        daemon_reload: true
+
+    - name: Configuring gap fill service
+      service:
+        name: gap_fill
         state: restarted
         enabled: true
         daemon_reload: true

--- a/ansible/templates/gap_fill.service.j2
+++ b/ansible/templates/gap_fill.service.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=block gap repair service
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart={{ app_root }}/gap_fill.sh
+User=range
+Group=range
+
+# Restart every >2 seconds to avoid StartLimitInterval failure
+RestartSec=30
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/templates/gap_fill.sh.j2
+++ b/ansible/templates/gap_fill.sh.j2
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+while true; do
+    # The SQL query
+    SQL_QUERY="select blocks.number + 1 gap_start from blocks where blocks.number >= 261504662 AND NOT EXISTS ( SELECT NULL FROM blocks b WHERE b.number = blocks.number + 1 ) order by blocks.number asc limit 10;"
+
+    # Execute the query and store results in an array
+    readarray -t gap_starts < <(PGPASSWORD="your_password" psql -d solana -t -c "$SQL_QUERY")
+
+    # Flag to check if any gaps were found
+    gaps_found=false
+
+    for gap_start in "${gap_starts[@]}"; do
+        # Remove leading/trailing whitespace
+        gap_start=$(echo $gap_start | xargs)
+        if [[ "$gap_start" == "" ]]; then 
+            continue
+        fi;
+        echo "Gap found starting at block: $gap_start"
+        {{ app_root }}/sb_dl --log-file {{ app_root }}/logs/sb_dl_gap_repair.log --config {{ app_root }}/config.yaml services repair-gaps --starting-number "$gap_start"
+    done
+
+done

--- a/crates/db/migrations/2024-09-09-153928_copy_blocks/down.sql
+++ b/crates/db/migrations/2024-09-09-153928_copy_blocks/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE blocks_2;

--- a/crates/db/migrations/2024-09-09-153928_copy_blocks/up.sql
+++ b/crates/db/migrations/2024-09-09-153928_copy_blocks/up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE blocks_2 (
+    id UUID NOT NULL PRIMARY KEY DEFAULT uuid_generate_v4(),
+    number BIGINT NOT NULL UNIQUE,
+    slot BIGINT UNIQUE NULL,
+    data JSONB NOT NULL
+);

--- a/crates/db/src/client.rs
+++ b/crates/db/src/client.rs
@@ -2,7 +2,9 @@ use anyhow::{anyhow, Context};
 use diesel::{prelude::*, sql_types::BigInt};
 use uuid::Uuid;
 
-use crate::models::{Blocks, Idls, NewBlock, Programs};
+use crate::models::{
+    BlockTableChoice, Blocks, DbBlocks, DbBlocks2, Idls, NewBlock, NewBlockTrait, Programs,
+};
 
 #[derive(Clone, Copy)]
 pub struct Client {}
@@ -21,16 +23,37 @@ pub enum BlockFilter {
 
 impl Client {
     /// Returns the slot number of blocks which we have indexed
-    pub fn indexed_blocks(self, conn: &mut PgConnection) -> anyhow::Result<Vec<Option<i64>>> {
-        use crate::schema::blocks::dsl::*;
-        let numbers: Vec<Option<i64>> = blocks
-            .select(slot)
-            .get_results(conn)
-            .with_context(|| "failed to select block numbers")?;
+    pub fn indexed_blocks(
+        self,
+        conn: &mut PgConnection,
+        block_table_choice: BlockTableChoice,
+    ) -> anyhow::Result<Vec<Option<i64>>> {
+        let numbers: Vec<Option<i64>> = match block_table_choice {
+            BlockTableChoice::Blocks => {
+                use super::schema::blocks::dsl::{self, blocks};
+                blocks
+                    .select(dsl::slot)
+                    .get_results(conn)
+                    .with_context(|| "failed to select block numbers")?
+            }
+            BlockTableChoice::Blocks2 => {
+                use super::schema::blocks_2::dsl::{self, blocks_2};
+                blocks_2
+                    .select(dsl::slot)
+                    .get_results(conn)
+                    .with_context(|| "failed to select block numbers")?
+            }
+        };
+
         Ok(numbers)
     }
     /// Returns up to `limit` blocks which do not have the slot column set
-    pub fn slot_is_null(self, conn: &mut PgConnection, limit: i64, excluded_blocks: &[i64]) -> anyhow::Result<Vec<Blocks>> {
+    pub fn slot_is_null(
+        self,
+        conn: &mut PgConnection,
+        limit: i64,
+        excluded_blocks: &[i64],
+    ) -> anyhow::Result<Vec<Blocks>> {
         use crate::schema::blocks::dsl::*;
         let mut query = blocks.into_boxed().filter(slot.is_null());
 
@@ -38,13 +61,19 @@ impl Client {
             query = query.filter(number.ne(excluded_block));
         }
 
-        
-        Ok(
-            query
+        Ok(query
             .limit(limit)
-            .select(Blocks::as_select())
+            .select(DbBlocks::as_select())
             .load(conn)
-            .with_context(|| "failed to load blocks")?)
+            .with_context(|| "failed to load blocks")?
+            .into_iter()
+            .map(|block| Blocks {
+                id: block.id,
+                number: block.number,
+                data: block.data,
+                slot: block.slot,
+            })
+            .collect())
     }
     /// Returns up to `limit` blocks which have slot and number as the same
     pub fn slot_equals_blocks(
@@ -56,9 +85,17 @@ impl Client {
         Ok(blocks
             .filter(number.nullable().eq(slot))
             .limit(limit)
-            .select(Blocks::as_select())
+            .select(DbBlocks::as_select())
             .load(conn)
-            .with_context(|| "failed to load blocks")?)
+            .with_context(|| "failed to load blocks")?
+            .into_iter()
+            .map(|block| Blocks {
+                id: block.id,
+                number: block.number,
+                data: block.data,
+                slot: block.slot,
+            })
+            .collect())
     }
     pub fn indexed_program_ids(self, conn: &mut PgConnection) -> anyhow::Result<Vec<String>> {
         use crate::schema::programs::dsl::*;
@@ -73,45 +110,115 @@ impl Client {
         self,
         conn: &mut PgConnection,
         filter: BlockFilter,
+        block_table_choice: BlockTableChoice,
     ) -> anyhow::Result<Vec<Blocks>> {
-        use crate::schema::blocks::dsl::*;
+        use crate::schema::{blocks, blocks_2};
         match filter {
-            BlockFilter::Number(blk_num) => Ok(blocks
-                .filter(number.eq(blk_num))
-                .select(Blocks::as_select())
-                .load(conn)?),
-            BlockFilter::Slot(slot_num) => Ok(blocks
-                .filter(slot.eq(Some(slot_num)))
-                .select(Blocks::as_select())
-                .load(conn)?),
-            BlockFilter::FirstBlock => Ok(blocks
-                .order(number.asc())
-                .limit(1)
-                .select(Blocks::as_select())
-                .load(conn)?),
-            BlockFilter::All => Ok(blocks.select(Blocks::as_select()).load(conn)?),
+            BlockFilter::Number(blk_num) => match block_table_choice {
+                BlockTableChoice::Blocks => Ok(blocks::dsl::blocks
+                    .filter(blocks::dsl::number.eq(blk_num))
+                    .select(DbBlocks::as_select())
+                    .load(conn)?
+                    .into_iter()
+                    .map(|block| Blocks {
+                        id: block.id,
+                        number: block.number,
+                        data: block.data,
+                        slot: block.slot,
+                    })
+                    .collect()),
+                BlockTableChoice::Blocks2 => Ok(blocks_2::dsl::blocks_2
+                    .filter(blocks_2::dsl::number.eq(blk_num))
+                    .select(DbBlocks2::as_select())
+                    .load(conn)?
+                    .into_iter()
+                    .map(|block| Blocks {
+                        id: block.id,
+                        number: block.number,
+                        data: block.data,
+                        slot: block.slot,
+                    })
+                    .collect()),
+            },
+            BlockFilter::Slot(slot_num) => match block_table_choice {
+                BlockTableChoice::Blocks => Ok(blocks::dsl::blocks
+                    .filter(blocks::dsl::slot.eq(slot_num))
+                    .select(DbBlocks::as_select())
+                    .load(conn)?
+                    .into_iter()
+                    .map(|block| Blocks {
+                        id: block.id,
+                        number: block.number,
+                        data: block.data,
+                        slot: block.slot,
+                    })
+                    .collect()),
+                BlockTableChoice::Blocks2 => Ok(blocks_2::dsl::blocks_2
+                    .filter(blocks_2::dsl::slot.eq(slot_num))
+                    .select(DbBlocks2::as_select())
+                    .load(conn)?
+                    .into_iter()
+                    .map(|block| Blocks {
+                        id: block.id,
+                        number: block.number,
+                        data: block.data,
+                        slot: block.slot,
+                    })
+                    .collect()),
+            },
+            BlockFilter::FirstBlock => match block_table_choice {
+                BlockTableChoice::Blocks => Ok(blocks::dsl::blocks
+                    .order(blocks::dsl::number.asc())
+                    .limit(1)
+                    .select(DbBlocks::as_select())
+                    .load(conn)?
+                    .into_iter()
+                    .map(|block| Blocks {
+                        id: block.id,
+                        number: block.number,
+                        data: block.data,
+                        slot: block.slot,
+                    })
+                    .collect()),
+                BlockTableChoice::Blocks2 => Ok(blocks_2::dsl::blocks_2
+                    .order(blocks_2::dsl::number.asc())
+                    .limit(1)
+                    .select(DbBlocks2::as_select())
+                    .load(conn)?
+                    .into_iter()
+                    .map(|block| Blocks {
+                        id: block.id,
+                        number: block.number,
+                        data: block.data,
+                        slot: block.slot,
+                    })
+                    .collect()),
+            },
+            BlockFilter::All => match block_table_choice {
+                BlockTableChoice::Blocks => Ok(blocks::dsl::blocks
+                    .select(DbBlocks::as_select())
+                    .load(conn)?
+                    .into_iter()
+                    .map(|block| Blocks {
+                        id: block.id,
+                        number: block.number,
+                        data: block.data,
+                        slot: block.slot,
+                    })
+                    .collect()),
+                BlockTableChoice::Blocks2 => Ok(blocks_2::dsl::blocks_2
+                    .select(DbBlocks2::as_select())
+                    .load(conn)?
+                    .into_iter()
+                    .map(|block| Blocks {
+                        id: block.id,
+                        number: block.number,
+                        data: block.data,
+                        slot: block.slot,
+                    })
+                    .collect()),
+            },
         }
-    }
-    /// Inserts a new block
-    pub fn insert_block(
-        self,
-        conn: &mut PgConnection,
-        block_number: i64,
-        slot_number: Option<i64>,
-        block_data: serde_json::Value,
-    ) -> anyhow::Result<()> {
-        use crate::schema::blocks::dsl::*;
-        NewBlock {
-            number: block_number,
-            data: block_data,
-            slot: slot_number,
-        }
-        .insert_into(blocks)
-        // silently ignore duplicate constriants
-        .on_conflict_do_nothing()
-        .execute(conn)
-        .with_context(|| "failed to insert block")?;
-        Ok(())
     }
     /// Used to update blocks which have missing slot information
     pub fn update_block_slot(
@@ -120,11 +227,23 @@ impl Client {
         block_id: Uuid,
         new_block_number: i64,
         slot_number: i64,
+        block_table_choice: BlockTableChoice,
     ) -> anyhow::Result<()> {
-        use crate::schema::blocks::dsl::*;
-        diesel::update(blocks.filter(id.eq(block_id)))
-            .set((slot.eq(slot_number), number.eq(new_block_number)))
-            .execute(conn)?;
+        match block_table_choice {
+            BlockTableChoice::Blocks => {
+                use crate::schema::blocks::dsl::{self, blocks};
+                diesel::update(blocks.filter(dsl::id.eq(block_id)))
+                    .set((dsl::slot.eq(slot_number), dsl::number.eq(new_block_number)))
+                    .execute(conn)?;
+            }
+            BlockTableChoice::Blocks2 => {
+                use crate::schema::blocks_2::dsl::{self, blocks_2};
+                diesel::update(blocks_2.filter(dsl::id.eq(block_id)))
+                    .set((dsl::slot.eq(slot_number), dsl::number.eq(new_block_number)))
+                    .execute(conn)?;
+            }
+        }
+
         Ok(())
     }
     pub fn insert_or_update_idl(
@@ -218,32 +337,68 @@ impl Client {
         conn: &mut PgConnection,
         block_number: i64,
         slot_number: i64,
+        block_table_choice: BlockTableChoice,
     ) -> anyhow::Result<()> {
-        use crate::schema::blocks::dsl::*;
         conn.transaction::<_, anyhow::Error, _>(|conn| {
-            match blocks
-                .filter(number.eq(&block_number))
-                .select(Blocks::as_select())
-                .limit(1)
-                .load(conn)
-            {
-                Ok(mut block_infos) => {
-                    if block_infos.is_empty() {
-                        return Ok(());
-                    } else {
-                        let mut block = std::mem::take(&mut block_infos[0]);
-                        block.slot = Some(slot_number);
-                        diesel::update(blocks.filter(id.eq(block.id)))
-                            .set(block)
-                            .execute(conn)?;
+            match block_table_choice {
+                BlockTableChoice::Blocks => {
+                    use crate::schema::blocks;
+                    match blocks::dsl::blocks
+                        .filter(blocks::dsl::number.eq(&block_number))
+                        .select(DbBlocks::as_select())
+                        .limit(1)
+                        .load(conn)
+                    {
+                        Ok(mut block_infos) => {
+                            if block_infos.is_empty() {
+                                return Ok(());
+                            } else {
+                                let mut block = std::mem::take(&mut block_infos[0]);
+                                block.slot = Some(slot_number);
+                                diesel::update(
+                                    blocks::dsl::blocks.filter(blocks::dsl::id.eq(block.id)),
+                                )
+                                .set(block)
+                                .execute(conn)?;
+                            }
+                        }
+                        Err(err) => {
+                            return Err(anyhow!(
+                                "failed to check for block({block_number}) {err:#?}"
+                            ))
+                        }
                     }
                 }
-                Err(err) => {
-                    return Err(anyhow!(
-                        "failed to check for block({block_number}) {err:#?}"
-                    ))
+                BlockTableChoice::Blocks2 => {
+                    use crate::schema::blocks_2;
+                    match blocks_2::dsl::blocks_2
+                        .filter(blocks_2::dsl::number.eq(&block_number))
+                        .select(DbBlocks2::as_select())
+                        .limit(1)
+                        .load(conn)
+                    {
+                        Ok(mut block_infos) => {
+                            if block_infos.is_empty() {
+                                return Ok(());
+                            } else {
+                                let mut block = std::mem::take(&mut block_infos[0]);
+                                block.slot = Some(slot_number);
+                                diesel::update(
+                                    blocks_2::dsl::blocks_2.filter(blocks_2::dsl::id.eq(block.id)),
+                                )
+                                .set(block)
+                                .execute(conn)?;
+                            }
+                        }
+                        Err(err) => {
+                            return Err(anyhow!(
+                                "failed to check for block({block_number}) {err:#?}"
+                            ))
+                        }
+                    }
                 }
             }
+
             Ok(())
         })?;
         Ok(())
@@ -251,27 +406,85 @@ impl Client {
     /// Given a starting block height, determine the next block for which we have data available.
     ///
     /// If starting_number == 10, and the return value is 20, this means we are missing data for blocks 10 -> 20
-    pub fn find_gap_end(self, conn: &mut PgConnection, starting_number: i64) -> anyhow::Result<i64> {
-        use crate::schema::blocks::dsl::*;
+    pub fn find_gap_end(
+        self,
+        conn: &mut PgConnection,
+        starting_number: i64,
+        block_table_choice: BlockTableChoice,
+    ) -> anyhow::Result<i64> {
+        use crate::schema::{blocks, blocks_2};
         let end_number;
         let mut next_number = starting_number + 1;
         loop {
-            match blocks
-            .filter(
-                number.eq(&next_number)
-            )
-            .select(Blocks::as_select())
-            .limit(1)
-            .load(conn) {
-                Ok(block_infos) => if !block_infos.is_empty() {
-                    end_number = next_number-1;
-                    break;
+            match block_table_choice {
+                BlockTableChoice::Blocks => {
+                    match blocks::dsl::blocks
+                        .filter(blocks::dsl::number.eq(&next_number))
+                        .select(DbBlocks::as_select())
+                        .limit(1)
+                        .load(conn)
+                    {
+                        Ok(block_infos) => {
+                            if !block_infos.is_empty() {
+                                end_number = next_number - 1;
+                                break;
+                            }
+                        }
+                        Err(err) => {
+                            return Err(anyhow!(
+                                "failed to check for block({next_number}) {err:#?}"
+                            ))
+                        }
+                    }
                 }
-                Err(err) => return Err(anyhow!("failed to check for block({next_number}) {err:#?}"))
+                BlockTableChoice::Blocks2 => match blocks_2::dsl::blocks_2
+                    .filter(blocks_2::dsl::number.eq(&next_number))
+                    .select(DbBlocks2::as_select())
+                    .limit(1)
+                    .load(conn)
+                {
+                    Ok(block_infos) => {
+                        if !block_infos.is_empty() {
+                            end_number = next_number - 1;
+                            break;
+                        }
+                    }
+                    Err(err) => {
+                        return Err(anyhow!("failed to check for block({next_number}) {err:#?}"))
+                    }
+                },
             }
+
             next_number += 1;
         }
 
         Ok(end_number)
+    }
+
+    pub fn insert_block(
+        &self,
+        conn: &mut PgConnection,
+        new_block: impl NewBlockTrait,
+    ) -> anyhow::Result<()> {
+        let nb = NewBlock {
+            number: new_block.number(),
+            data: new_block.data(),
+            slot: new_block.slot(),
+        };
+        match new_block.table_choice() {
+            BlockTableChoice::Blocks => {
+                nb.insert_into(crate::schema::blocks::table)
+                    .on_conflict_do_nothing()
+                    .execute(conn)
+                    .with_context(|| "failed to insert into blocks")?;
+            }
+            BlockTableChoice::Blocks2 => {
+                nb.insert_into(crate::schema::blocks_2::table)
+                    .on_conflict_do_nothing()
+                    .execute(conn)
+                    .with_context(|| "failed to insert into blocks")?;
+            }
+        }
+        Ok(())
     }
 }

--- a/crates/db/src/client.rs
+++ b/crates/db/src/client.rs
@@ -107,6 +107,8 @@ impl Client {
             slot: slot_number,
         }
         .insert_into(blocks)
+        // silently ignore duplicate constriants
+        .on_conflict_do_nothing()
         .execute(conn)
         .with_context(|| "failed to insert block")?;
         Ok(())

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -22,10 +22,11 @@ pub fn new_connection(path: &str) -> anyhow::Result<PgConnection> {
 }
 
 /// establishes a new connection pool manager to postgres
-pub fn new_connection_pool(db_url: &str) -> Result<Pool<ConnectionManager<PgConnection>>> {
+pub fn new_connection_pool(db_url: &str, max_size: u32) -> Result<Pool<ConnectionManager<PgConnection>>> {
     let manager = ConnectionManager::<PgConnection>::new(db_url);
 
     Pool::builder()
+        .max_size(max_size)
         .test_on_check_out(true)
         .build(manager).with_context(|| "failed to build connection pool")
 }

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -1,7 +1,10 @@
 use {
-    anyhow::Result,
-    deadpool_diesel::{Manager, Pool},
-    diesel::prelude::*,
+    anyhow::{Context, Result},
+    diesel::{
+        r2d2::{ConnectionManager, Pool, PooledConnection},
+
+        prelude::*,
+    },
 };
 //use diesel::{Connection, PgConnection};
 pub mod client;
@@ -19,7 +22,10 @@ pub fn new_connection(path: &str) -> anyhow::Result<PgConnection> {
 }
 
 /// establishes a new connection pool manager to postgres
-pub fn new_connection_pool(db_url: &str) -> Result<Pool<Manager<PgConnection>>> {
-    let manager = deadpool_diesel::postgres::Manager::new(db_url, deadpool_diesel::Runtime::Tokio1);
-    Ok(deadpool_diesel::postgres::Pool::builder(manager).build()?)
+pub fn new_connection_pool(db_url: &str) -> Result<Pool<ConnectionManager<PgConnection>>> {
+    let manager = ConnectionManager::<PgConnection>::new(db_url);
+
+    Pool::builder()
+        .test_on_check_out(true)
+        .build(manager).with_context(|| "failed to build connection pool")
 }

--- a/crates/db/src/models.rs
+++ b/crates/db/src/models.rs
@@ -1,9 +1,47 @@
-use {diesel::prelude::*, uuid::Uuid};
+use {anyhow::anyhow, diesel::{prelude::*, query_builder::BoxedSqlQuery, sql_types::{BigInt, Jsonb, Nullable}}, uuid::Uuid};
+
+#[derive(Clone, Copy)]
+#[repr(u8)]
+pub enum BlockTableChoice{
+    Blocks = 1,
+    Blocks2 = 2,
+}
+impl TryFrom<u8> for BlockTableChoice {
+    type Error = anyhow::Error;
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        if value == 1 {
+            return Ok(BlockTableChoice::Blocks)
+        } else if value == 2 {
+            return Ok(BlockTableChoice::Blocks2)
+        } else {
+            Err(anyhow!("invalid block table selection"))
+        }
+    }
+}
 
 #[derive(
     Queryable, AsChangeset, Identifiable, Debug, Clone, Selectable, Default, PartialEq, Eq,
 )]
 #[diesel(table_name = super::schema::blocks)]
+pub struct DbBlocks {
+    pub id: Uuid,
+    pub number: i64,
+    pub data: serde_json::Value,
+    pub slot: Option<i64>,
+}
+#[derive(
+    Queryable, AsChangeset, Identifiable, Debug, Clone, Selectable, Default, PartialEq, Eq,
+)]
+#[diesel(table_name = super::schema::blocks_2)]
+pub struct DbBlocks2 {
+    pub id: Uuid,
+    pub number: i64,
+    pub data: serde_json::Value,
+    pub slot: Option<i64>,
+}
+
+/// A type which DbBlocks and DbBlocks2 can be converted into to return the same data type
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct Blocks {
     pub id: Uuid,
     pub number: i64,
@@ -31,7 +69,8 @@ pub struct Programs {
 
 #[derive(Insertable)]
 #[diesel(table_name = super::schema::blocks)]
-pub struct NewBlock {
+#[diesel(table_name = super::schema::blocks_2)]
+pub struct NewBlock{
     pub number: i64,
     pub data: serde_json::Value,
     pub slot: Option<i64>,
@@ -44,4 +83,48 @@ pub struct NewIdl {
     pub begin_height: i64,
     pub end_height: Option<i64>,
     pub idl: serde_json::Value,
+}
+
+#[derive(Insertable)]
+#[diesel(table_name = super::schema::blocks_2)]
+pub struct NewBlock2 {
+    pub number: i64,
+    pub data: serde_json::Value,
+    pub slot: Option<i64>,
+}
+
+pub trait NewBlockTrait {
+    fn number(&self) -> i64;
+    fn data(&self) -> serde_json::Value;
+    fn slot(&self) -> Option<i64>;
+    fn table_choice(&self) -> BlockTableChoice;
+}
+
+impl NewBlockTrait for NewBlock {
+    fn data(&self) -> serde_json::Value {
+        self.data.clone()
+    }
+    fn number(&self) -> i64 {
+        self.number
+    }
+    fn slot(&self) -> Option<i64> {
+        self.slot
+    }
+    fn table_choice(&self) -> BlockTableChoice {
+        BlockTableChoice::Blocks
+    }
+}
+impl NewBlockTrait for NewBlock2 {
+    fn data(&self) -> serde_json::Value {
+        self.data.clone()
+    }
+    fn number(&self) -> i64 {
+        self.number
+    }
+    fn slot(&self) -> Option<i64> {
+        self.slot
+    }
+    fn table_choice(&self) -> BlockTableChoice {
+        BlockTableChoice::Blocks2
+    }
 }

--- a/crates/db/src/schema.rs
+++ b/crates/db/src/schema.rs
@@ -14,6 +14,17 @@ diesel::table! {
 diesel::table! {
     use diesel::sql_types::*;
 
+    blocks_2 (id) {
+        id -> Uuid,
+        number -> Int8,
+        slot -> Nullable<Int8>,
+        data -> Jsonb,
+    }
+}
+
+diesel::table! {
+    use diesel::sql_types::*;
+
     idls (id, begin_height) {
         id -> Varchar,
         begin_height -> Int8,
@@ -33,4 +44,9 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(blocks, idls, programs,);
+diesel::allow_tables_to_appear_in_same_query!(
+    blocks,
+    blocks_2,
+    idls,
+    programs,
+);

--- a/crates/db/src/test_utils.rs
+++ b/crates/db/src/test_utils.rs
@@ -35,6 +35,7 @@ impl TestDb {
     pub fn delete_all_tables(&self) {
         let mut conn = self.conn();
         let _ = diesel::delete(super::schema::blocks::dsl::blocks).execute(&mut conn);
+        let _ = diesel::delete(super::schema::blocks_2::dsl::blocks_2).execute(&mut conn);
     }
     pub fn name(&self) -> String {
         self.name.clone()

--- a/crates/db/src/tests.rs
+++ b/crates/db/src/tests.rs
@@ -1,12 +1,18 @@
 use std::collections::HashSet;
 
 use client::{BlockFilter, Client};
+use models::{BlockTableChoice, NewBlock, NewBlock2, NewBlockTrait};
 
 use crate::{migrations::run_migrations, test_utils::TestDb};
 
 use super::*;
 #[test]
 fn test_blocks() {
+    {
+        let test_db = TestDb::new();
+        test_db.delete_all_tables();
+        drop(test_db);
+    }
     let test_db = TestDb::new();
     run_migrations(&mut test_db.conn());
     let mut db_conn = test_db.conn();
@@ -15,62 +21,147 @@ fn test_blocks() {
         client
             .insert_block(
                 &mut db_conn,
-                i,
-                Some(i + 1),
-                serde_json::json!({
-                    "a": "b"
-                }),
+                NewBlock {
+                    number: i,
+                    data: serde_json::json!({
+                        "a": "b"
+                    }),
+                    slot: Some(i+1)
+                },
             )
             .unwrap();
-    }
-    for i in 200..300 {
+        let res = client.select_block(&mut db_conn, BlockFilter::Number(i), BlockTableChoice::Blocks).unwrap();
+        assert_eq!(res.len(), 1);
+        let res = client.select_block(&mut db_conn, BlockFilter::Number(i), BlockTableChoice::Blocks2).unwrap();
+        assert_eq!(res.len(), 0);
         client
             .insert_block(
                 &mut db_conn,
-                i,
-                None,
-                serde_json::json!({
-                    "a": "b"
-                }),
+                NewBlock2 {
+                    number: i,
+                    data: serde_json::json!({
+                        "a": "b"
+                    }),
+                    slot: Some(i+1)
+                },
             )
             .unwrap();
+        let res = client.select_block(&mut db_conn, BlockFilter::Number(i), BlockTableChoice::Blocks).unwrap();
+        assert_eq!(res.len(), 1);
+        let res = client.select_block(&mut db_conn, BlockFilter::Number(i), BlockTableChoice::Blocks2).unwrap();
+        assert_eq!(res.len(), 1);
+        let res = client.select_block(&mut db_conn, BlockFilter::Number(i), BlockTableChoice::Blocks).unwrap();
+        assert_eq!(res.len(), 1);
+    }
+
+    for i in 200..300 {
+        client
+        .insert_block(
+            &mut db_conn,
+            NewBlock {
+                number: i,
+                data: serde_json::json!({
+                    "a": "b"
+                }),
+                slot: None
+            },
+        )
+        .unwrap();
+        let res = client.select_block(&mut db_conn, BlockFilter::Number(i), BlockTableChoice::Blocks).unwrap();
+        assert_eq!(res.len(), 1);
+        let res = client.select_block(&mut db_conn, BlockFilter::Number(i), BlockTableChoice::Blocks2).unwrap();
+        assert_eq!(res.len(), 0);
+        client
+        .insert_block(
+            &mut db_conn,
+            NewBlock2 {
+                number: i,
+                data: serde_json::json!({
+                    "a": "b"
+                }),
+                slot: None
+            },
+        )
+            .unwrap();
+        let res = client.select_block(&mut db_conn, BlockFilter::Number(i), BlockTableChoice::Blocks).unwrap();
+        assert_eq!(res.len(), 1);
+        let res = client.select_block(&mut db_conn, BlockFilter::Number(i), BlockTableChoice::Blocks2).unwrap();
+        assert_eq!(res.len(), 1);
     }
     // check that setting slot by default worked
     let indexed_blocks: HashSet<i64> = client
-        .indexed_blocks(&mut db_conn)
+        .indexed_blocks(&mut db_conn, BlockTableChoice::Blocks)
         .unwrap()
         .into_iter()
         .filter_map(|block| Some(block?))
         .collect();
     let mut expected_set = (2..101).into_iter().collect::<HashSet<i64>>();
     assert_eq!(expected_set, indexed_blocks);
+    // check that setting slot by default worked
+    let indexed_blocks: HashSet<i64> = client
+        .indexed_blocks(&mut db_conn, BlockTableChoice::Blocks2)
+        .unwrap()
+        .into_iter()
+        .filter_map(|block| Some(block?))
+        .collect();
+    assert_eq!(expected_set, indexed_blocks);
 
     // update slot number for blocks which are missing it
     for i in 200..300 {
         let block = client.select_block(
             &mut db_conn, 
-            BlockFilter::Number(i)
+            BlockFilter::Number(i),
+            BlockTableChoice::Blocks
         ).unwrap();
         client.update_block_slot(
             &mut db_conn,
             block[0].id,
             i,
             i + 1,
+            BlockTableChoice::Blocks
         ).unwrap();
-        let block2 = client.select_block(&mut db_conn, BlockFilter::Number(i)).unwrap();
+        let block2 = client.select_block(&mut db_conn, BlockFilter::Number(i), BlockTableChoice::Blocks).unwrap();
         assert_eq!(block2[0].number, block[0].number);
         assert_eq!(block2[0].slot, Some(i+1));
         assert_ne!(block2[0].slot, block[0].slot);
         assert_eq!(block2[0].data, block[0].data);
-        //client.update_block_slot(&mut db_conn, i, i, i + 1).unwrap();
+        // verify all data is the same as the above except that the slot is still none
+        let block2 = client.select_block(&mut db_conn, BlockFilter::Number(i), BlockTableChoice::Blocks2).unwrap();
+        assert_eq!(block2[0].number, block[0].number);
+        assert!(block2[0].slot.is_none());
+        assert_eq!(block2[0].data, block[0].data);
+        let block = client.select_block(
+            &mut db_conn, 
+            BlockFilter::Number(i),
+            BlockTableChoice::Blocks2
+        ).unwrap();
+        client.update_block_slot(
+            &mut db_conn,
+            block[0].id,
+            i,
+            i + 1,
+            BlockTableChoice::Blocks2
+        ).unwrap();
+        let block2 = client.select_block(&mut db_conn, BlockFilter::Number(i), BlockTableChoice::Blocks2).unwrap();
+        assert_eq!(block2[0].number, block[0].number);
+        assert_eq!(block2[0].slot, Some(i+1));
+        assert_ne!(block2[0].slot, block[0].slot);
+        assert_eq!(block2[0].data, block[0].data);
     }
     let indexed_blocks: HashSet<i64> = client
-        .indexed_blocks(&mut db_conn)
+        .indexed_blocks(&mut db_conn, BlockTableChoice::Blocks)
         .unwrap()
         .into_iter()
         .filter_map(|block| Some(block?))
         .collect();
     expected_set.extend((201..301).into_iter().collect::<HashSet<i64>>());
+    assert_eq!(expected_set, indexed_blocks);
+    let indexed_blocks: HashSet<i64> = client
+        .indexed_blocks(&mut db_conn, BlockTableChoice::Blocks2)
+        .unwrap()
+        .into_iter()
+        .filter_map(|block| Some(block?))
+        .collect();
     assert_eq!(expected_set, indexed_blocks);
 
     // now test the edge case where block_number == slot number and slot number is not null
@@ -78,29 +169,65 @@ fn test_blocks() {
         client
             .insert_block(
                 &mut db_conn,
-                i,
-                Some(i),
-                serde_json::json!({
-                    "a": "b"
-                }),
+                NewBlock {
+                    number: i,
+                    slot: Some(i),
+                    data: serde_json::json!({
+                        "a": "b"
+                    }),
+                }
             )
             .unwrap();
         let block_1 = client
-            .select_block(&mut db_conn, client::BlockFilter::Slot(i))
+            .select_block(&mut db_conn, client::BlockFilter::Slot(i), BlockTableChoice::Blocks)
             .unwrap();
         let block_2 = client
-            .select_block(&mut db_conn, client::BlockFilter::Number(i))
+            .select_block(&mut db_conn, client::BlockFilter::Number(i), BlockTableChoice::Blocks)
             .unwrap();
         assert_eq!(block_1, block_2);
         // now update the block number
         client
-            .update_block_slot(&mut db_conn, block_1[0].id, i + 1000, i)
+            .update_block_slot(&mut db_conn, block_1[0].id, i + 1000, i, BlockTableChoice::Blocks)
             .unwrap();
         let block_3 = client
-            .select_block(&mut db_conn, client::BlockFilter::Slot(i))
+            .select_block(&mut db_conn, client::BlockFilter::Slot(i), BlockTableChoice::Blocks)
             .unwrap();
         let block_4 = client
-            .select_block(&mut db_conn, client::BlockFilter::Number(i + 1000))
+            .select_block(&mut db_conn, client::BlockFilter::Number(i + 1000), BlockTableChoice::Blocks)
+            .unwrap();
+        assert_eq!(block_3, block_4);
+        assert_eq!(block_1[0].data, block_3[0].data);
+    }
+    // now test the edge case where block_number == slot number and slot number is not null
+    for i in 1000..1500 {
+        client
+            .insert_block(
+                &mut db_conn,
+                NewBlock2 {
+                    number: i,
+                    slot: Some(i),
+                    data: serde_json::json!({
+                        "a": "b"
+                    }),
+                }
+            )
+            .unwrap();
+        let block_1 = client
+            .select_block(&mut db_conn, client::BlockFilter::Slot(i), BlockTableChoice::Blocks2)
+            .unwrap();
+        let block_2 = client
+            .select_block(&mut db_conn, client::BlockFilter::Number(i), BlockTableChoice::Blocks2)
+            .unwrap();
+        assert_eq!(block_1, block_2);
+        // now update the block number
+        client
+            .update_block_slot(&mut db_conn, block_1[0].id, i + 1000, i, BlockTableChoice::Blocks2)
+            .unwrap();
+        let block_3 = client
+            .select_block(&mut db_conn, client::BlockFilter::Slot(i), BlockTableChoice::Blocks2)
+            .unwrap();
+        let block_4 = client
+            .select_block(&mut db_conn, client::BlockFilter::Number(i + 1000), BlockTableChoice::Blocks2)
             .unwrap();
         assert_eq!(block_3, block_4);
         assert_eq!(block_1[0].data, block_3[0].data);
@@ -111,31 +238,68 @@ fn test_blocks() {
         client
             .insert_block(
                 &mut db_conn,
-                i,
-                None,
-                serde_json::json!({
-                    "a": "b"
-                }),
+                NewBlock {
+                    number: i,
+                    slot: None,
+                    data: serde_json::json!({
+                        "a": "b"
+                    })
+                },
             )
             .unwrap();
         let block_1 = client
-            .select_block(&mut db_conn, client::BlockFilter::Slot(i))
+            .select_block(&mut db_conn, client::BlockFilter::Slot(i),BlockTableChoice::Blocks)
             .unwrap();
         let block_2 = client
-            .select_block(&mut db_conn, client::BlockFilter::Number(i))
+            .select_block(&mut db_conn, client::BlockFilter::Number(i),BlockTableChoice::Blocks)
             .unwrap();
         assert!(block_1.is_empty());
         assert_eq!(block_2[0].number, i);
         assert!(block_2[0].slot.is_none());
         // now update the block number
         client
-            .update_block_slot(&mut db_conn, block_2[0].id, i + 1000, i)
+            .update_block_slot(&mut db_conn, block_2[0].id, i + 1000, i, BlockTableChoice::Blocks)
             .unwrap();
         let block_3 = client
-            .select_block(&mut db_conn, client::BlockFilter::Slot(i))
+            .select_block(&mut db_conn, client::BlockFilter::Slot(i),BlockTableChoice::Blocks)
             .unwrap();
         let block_4 = client
-            .select_block(&mut db_conn, client::BlockFilter::Number(i + 1000))
+            .select_block(&mut db_conn, client::BlockFilter::Number(i + 1000),BlockTableChoice::Blocks)
+            .unwrap();
+        assert_eq!(block_3, block_4);
+    }
+    // test the edge case where block_number == slot_number and slot_number is null
+    for i in 3000..3500 {
+        client
+            .insert_block(
+                &mut db_conn,
+                NewBlock2 {
+                    number: i,
+                    slot: None,
+                    data: serde_json::json!({
+                        "a": "b"
+                    })
+                },
+            )
+            .unwrap();
+        let block_1 = client
+            .select_block(&mut db_conn, client::BlockFilter::Slot(i),BlockTableChoice::Blocks2)
+            .unwrap();
+        let block_2 = client
+            .select_block(&mut db_conn, client::BlockFilter::Number(i),BlockTableChoice::Blocks2)
+            .unwrap();
+        assert!(block_1.is_empty());
+        assert_eq!(block_2[0].number, i);
+        assert!(block_2[0].slot.is_none());
+        // now update the block number
+        client
+            .update_block_slot(&mut db_conn, block_2[0].id, i + 1000, i, BlockTableChoice::Blocks2)
+            .unwrap();
+        let block_3 = client
+            .select_block(&mut db_conn, client::BlockFilter::Slot(i),BlockTableChoice::Blocks2)
+            .unwrap();
+        let block_4 = client
+            .select_block(&mut db_conn, client::BlockFilter::Number(i + 1000),BlockTableChoice::Blocks2)
             .unwrap();
         assert_eq!(block_3, block_4);
     }
@@ -145,6 +309,11 @@ fn test_blocks() {
 
 #[test]
 fn test_update_slot() {
+    {
+        let test_db = TestDb::new();
+        test_db.delete_all_tables();
+        drop(test_db);
+    }
     let test_db = TestDb::new();
     run_migrations(&mut test_db.conn());
     let mut db_conn = test_db.conn();
@@ -153,15 +322,36 @@ fn test_update_slot() {
         client
             .insert_block(
                 &mut db_conn,
-                i,
-                None,
-                serde_json::json!({
-                    "a": i.to_string()
-                }),
+                NewBlock {
+                    number: i,
+                    slot: None,
+                    data: serde_json::json!({
+                        "a": i.to_string()
+                    })
+                },
             )
             .unwrap();
     }
-    let got_blocks: HashSet<i64> = client.select_block(&mut db_conn, BlockFilter::All).unwrap().into_iter().map(|block| block.number).collect();
+    let got_blocks: HashSet<i64> = client.select_block(&mut db_conn, BlockFilter::All, BlockTableChoice::Blocks).unwrap().into_iter().map(|block| block.number).collect();
+    assert_eq!(
+        got_blocks,
+        (100..300).collect::<HashSet<i64>>()
+    );
+    for i in 100..300 {
+        client
+            .insert_block(
+                &mut db_conn,
+                NewBlock2 {
+                    number: i,
+                    slot: None,
+                    data: serde_json::json!({
+                        "a": i.to_string()
+                    })
+                },
+            )
+            .unwrap();
+    }
+    let got_blocks: HashSet<i64> = client.select_block(&mut db_conn, BlockFilter::All, BlockTableChoice::Blocks2).unwrap().into_iter().map(|block| block.number).collect();
     assert_eq!(
         got_blocks,
         (100..300).collect::<HashSet<i64>>()
@@ -170,9 +360,10 @@ fn test_update_slot() {
         client.update_slot(
             &mut db_conn,
             i,
-            i+1000
+            i+1000,
+            BlockTableChoice::Blocks
         ).unwrap();
-        let block = &client.select_block(&mut db_conn, BlockFilter::Slot(i+1000)).unwrap()[0];
+        let block = &client.select_block(&mut db_conn, BlockFilter::Slot(i+1000), BlockTableChoice::Blocks).unwrap()[0];
         assert_eq!(
             block.data,
             serde_json::json!({
@@ -182,7 +373,26 @@ fn test_update_slot() {
         assert_eq!(block.number, i);
         assert_eq!(block.slot, Some(i+1000));
     }
-    let block = &client.select_block(&mut db_conn, BlockFilter::FirstBlock).unwrap()[0];
+    let block = &client.select_block(&mut db_conn, BlockFilter::FirstBlock, BlockTableChoice::Blocks).unwrap()[0];
+    assert_eq!(block.number, 100);
+    for i in 100..300 {
+        client.update_slot(
+            &mut db_conn,
+            i,
+            i+1000,
+            BlockTableChoice::Blocks2
+        ).unwrap();
+        let block = &client.select_block(&mut db_conn, BlockFilter::Slot(i+1000), BlockTableChoice::Blocks2).unwrap()[0];
+        assert_eq!(
+            block.data,
+            serde_json::json!({
+                "a": i.to_string()
+            })
+        );
+        assert_eq!(block.number, i);
+        assert_eq!(block.slot, Some(i+1000));
+    }
+    let block = &client.select_block(&mut db_conn, BlockFilter::FirstBlock, BlockTableChoice::Blocks2).unwrap()[0];
     assert_eq!(block.number, 100);
 
     drop(test_db);

--- a/crates/db/src/tests.rs
+++ b/crates/db/src/tests.rs
@@ -166,5 +166,8 @@ fn test_update_slot() {
         assert_eq!(block.number, i);
         assert_eq!(block.slot, Some(i+1000));
     }
+    let block = &client.select_block(&mut db_conn, BlockFilter::FirstBlock).unwrap()[0];
+    assert_eq!(block.number, 100);
+
     drop(test_db);
 }

--- a/crates/sb_dl/Cargo.toml
+++ b/crates/sb_dl/Cargo.toml
@@ -32,7 +32,7 @@ version = "0.4.1"
 features = ["postgres", "serde"]
 [dependencies.tokio]
 version = "1"
-features = ["full"]
+features = ["full", "parking_lot"]
 [dependencies.serde]
 version = "1"
 features = ["derive"]

--- a/crates/sb_dl/src/commands/db.rs
+++ b/crates/sb_dl/src/commands/db.rs
@@ -15,7 +15,7 @@ pub async fn fill_missing_slots_no_tx(
     let limit = matches.get_one::<i64>("limit").unwrap();
     let cfg = Config::load(config_path).await?;
     let rpc = Arc::new(RpcClient::new(cfg.rpc_url.clone()));
-    let pool = db::new_connection_pool(&cfg.db_url)?;
+    let pool = db::new_connection_pool(&cfg.db_url, 10)?;
     let mut conn = db::new_connection(&cfg.db_url)?;
     {
 
@@ -68,7 +68,7 @@ pub async fn fill_missing_slots(matches: &ArgMatches, config_path: &str) -> anyh
     let limit = matches.get_one::<i64>("limit").unwrap();
     let cfg = Config::load(config_path).await?;
     let rpc = Arc::new(RpcClient::new(cfg.rpc_url.clone()));
-    let pool = db::new_connection_pool(&cfg.db_url)?;
+    let pool = db::new_connection_pool(&cfg.db_url, 10)?;
     let mut conn = db::new_connection(&cfg.db_url)?;
     {
 

--- a/crates/sb_dl/src/commands/db.rs
+++ b/crates/sb_dl/src/commands/db.rs
@@ -111,7 +111,6 @@ pub async fn repair_invalid_slots(config_path: &str) -> anyhow::Result<()> {
         // increment block_number to repair the next available block
         block_number += 1;
     }
-    Ok(())
 }
 
 /// returns the slot for the given block, along with the tx hash used to determine this

--- a/crates/sb_dl/src/commands/db.rs
+++ b/crates/sb_dl/src/commands/db.rs
@@ -16,7 +16,7 @@ pub async fn fill_missing_slots(matches: &ArgMatches, config_path: &str) -> anyh
 
     let client = db::client::Client {};
 
-    let mut blocks = client.partial_blocks(&mut conn, *limit)?;
+    let mut blocks = client.slot_is_null(&mut conn, *limit)?;
     for block in blocks.iter_mut() {
         let block_data: UiConfirmedBlock = serde_json::from_value(std::mem::take(&mut block.data))?;
 

--- a/crates/sb_dl/src/commands/db.rs
+++ b/crates/sb_dl/src/commands/db.rs
@@ -1,5 +1,6 @@
+use anyhow::anyhow;
 use clap::ArgMatches;
-use db::migrations::run_migrations;
+use db::{client::BlockFilter, migrations::run_migrations};
 use sb_dl::config::Config;
 use solana_client::{nonblocking::rpc_client::RpcClient, rpc_config::RpcTransactionConfig};
 use solana_transaction_status::{EncodedTransaction, UiConfirmedBlock, UiTransactionEncoding};
@@ -17,38 +18,18 @@ pub async fn fill_missing_slots(matches: &ArgMatches, config_path: &str) -> anyh
 
     let mut blocks = client.partial_blocks(&mut conn, *limit)?;
     for block in blocks.iter_mut() {
-        let block_data: UiConfirmedBlock = serde_json::from_value(block.data.clone())?;
-        let sample_tx = block_data
-            .transactions
-            .clone()
-            .and_then(|vec| vec.into_iter().next());
-        let sample_tx_hash = if let Some(tx) = sample_tx {
-            if let EncodedTransaction::Json(tx) = &tx.transaction {
-                tx.signatures.clone()
-            } else {
-                vec![]
+        let block_data: UiConfirmedBlock = serde_json::from_value(std::mem::take(&mut block.data))?;
+
+        let (slot, sample_tx_hash) = match get_slot_for_block(&block_data, &rpc).await {
+            Ok(Some(slot)) => slot,
+            Ok(None) => {
+                log::warn!("failed to find slot for block({})", block.number);
+                continue;
             }
-        } else {
-            vec![]
-        };
-        // extract slot information
-        let slot = if !sample_tx_hash.is_empty() {
-            match rpc.get_transaction_with_config(&sample_tx_hash[0].parse()?, RpcTransactionConfig {
-                encoding: Some(UiTransactionEncoding::JsonParsed),
-                max_supported_transaction_version: Some(1),
-                ..Default::default()
-            }).await {
-                Ok(tx) => {
-                    tx.slot
-                }
-                Err(err) => {
-                    log::error!("failed to get tx({}) {err:#?}", sample_tx_hash[0]);
-                    continue;
-                }
+            Err(err) => {
+                log::error!("failed to find slot for block({}) {err:#?}", block.number);
+                continue;
             }
-        } else {
-            log::warn!("sample tx hash has no signature");
-            continue;
         };
         let new_block_number = if let Some(block_height) = block_data.block_height {
             block_height
@@ -60,12 +41,11 @@ pub async fn fill_missing_slots(matches: &ArgMatches, config_path: &str) -> anyh
             continue;
         };
         log::info!(
-            "block(slot={slot}, new_block_number={new_block_number} block.height={:?}, block.number={}, parent_slot={}, block_hash={}, sample_tx_hash={:?})",
+            "block(slot={slot}, new_block_number={new_block_number} block.height={:?}, block.number={}, parent_slot={}, block_hash={}, sample_tx_hash={sample_tx_hash})",
             block_data.block_height,
             block.number,
             block_data.parent_slot,
             block_data.blockhash,
-            sample_tx_hash
         );
         client.update_block_slot(
             &mut conn,
@@ -76,4 +56,110 @@ pub async fn fill_missing_slots(matches: &ArgMatches, config_path: &str) -> anyh
     }
 
     Ok(())
+}
+
+pub async fn repair_invalid_slots(config_path: &str) -> anyhow::Result<()> {
+    let cfg = Config::load(config_path).await?;
+    let rpc = RpcClient::new(cfg.rpc_url.clone());
+    let mut conn = db::new_connection(&cfg.db_url)?;
+
+    // perform db migrations
+    run_migrations(&mut conn);
+
+    let client = db::client::Client {};
+    // numbero f the block to repair, initially set to the very first block available
+    let mut block_number = client
+        .select_block(&mut conn, BlockFilter::FirstBlock)
+        .unwrap()[0]
+        .number;
+
+    loop {
+        let mut block = client.select_block(&mut conn, BlockFilter::Number(block_number))?;
+        let mut block = if block.is_empty() {
+            return Err(anyhow!("found no matching block({block_number})"));
+        } else if block.len() > 1 {
+            return Err(anyhow!("found too many blocks({block_number})"));
+        } else {
+            std::mem::take(&mut block[0])
+        };
+        let block_data: UiConfirmedBlock = serde_json::from_value(std::mem::take(&mut block.data))?;
+
+        let (slot, sample_tx_hash) = match get_slot_for_block(&block_data, &rpc).await {
+            Ok(Some(slot)) => slot,
+            Ok(None) => {
+                log::warn!("failed to find slot for block({})", block.number);
+                continue;
+            }
+            Err(err) => {
+                log::error!("failed to find slot for block({}) {err:#?}", block.number);
+                continue;
+            }
+        };
+
+        if let Some(stored_slot) = block.slot {
+            if stored_slot == slot as i64 {
+                // if the slot in the database entry is equal to the slot from a tx in the block
+                // we no longer need to repair any data since all additional blocks
+                // were indexed after correct slot calculation was added
+                log::warn!(
+                    "stored_slot({stored_slot}) == calculated_slot({slot}) no more repairs needed"
+                );
+                break;
+            }
+        }
+
+        client.update_slot(&mut conn, block.number, slot as i64)?;
+        log::info!(
+            "repaired block(number={}, slot={slot}, tx={sample_tx_hash})",
+            block.number
+        );
+
+        // increment block_number to repair the next available block
+        block_number += 1;
+    }
+    Ok(())
+}
+
+/// returns the slot for the given block, along with the tx hash used to determine this
+async fn get_slot_for_block(
+    block: &UiConfirmedBlock,
+    rpc: &RpcClient,
+) -> anyhow::Result<Option<(u64, String)>> {
+    let sample_tx = block
+        .transactions
+        .clone()
+        .and_then(|vec| vec.into_iter().next());
+    let sample_tx_hash = if let Some(tx) = sample_tx {
+        if let EncodedTransaction::Json(tx) = &tx.transaction {
+            tx.signatures.clone()
+        } else {
+            vec![]
+        }
+    } else {
+        vec![]
+    };
+    // extract slot information
+    let slot = if !sample_tx_hash.is_empty() {
+        match rpc
+            .get_transaction_with_config(
+                &sample_tx_hash[0].parse()?,
+                RpcTransactionConfig {
+                    encoding: Some(UiTransactionEncoding::JsonParsed),
+                    max_supported_transaction_version: Some(1),
+                    ..Default::default()
+                },
+            )
+            .await
+        {
+            Ok(tx) => tx.slot,
+            Err(err) => {
+                log::error!("failed to get tx({}) {err:#?}", sample_tx_hash[0]);
+                return Ok(None);
+            }
+        }
+    } else {
+        log::warn!("sample tx hash has no signature");
+        return Ok(None);
+    };
+    return Ok(Some((slot, sample_tx_hash[0].clone())));
 }

--- a/crates/sb_dl/src/commands/db.rs
+++ b/crates/sb_dl/src/commands/db.rs
@@ -98,13 +98,7 @@ pub async fn repair_invalid_slots(config_path: &str) -> anyhow::Result<()> {
 
         if let Some(stored_slot) = block.slot {
             if stored_slot == slot as i64 {
-                // if the slot in the database entry is equal to the slot from a tx in the block
-                // we no longer need to repair any data since all additional blocks
-                // were indexed after correct slot calculation was added
-                log::warn!(
-                    "stored_slot({stored_slot}) == calculated_slot({slot}) no more repairs needed"
-                );
-                break;
+                continue;
             }
         }
 

--- a/crates/sb_dl/src/commands/services/backfill.rs
+++ b/crates/sb_dl/src/commands/services/backfill.rs
@@ -38,7 +38,8 @@ pub async fn backfill(
     let client = Client{};
     let gap_end = client.find_gap_end(&mut conn, *starting_number)?;
 
-    for missing_block in *starting_number-10..gap_end {
+    // start trying to repair gaps at the block immediately preceeding the current missing block
+    for missing_block in *starting_number-1..gap_end {
         // get block info for the previous block which isn't missing
         let blocks = client.select_block(&mut conn, BlockFilter::Number(missing_block - 1))?;
         if blocks.is_empty() {

--- a/crates/sb_dl/src/commands/services/backfill.rs
+++ b/crates/sb_dl/src/commands/services/backfill.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use anyhow::{anyhow, Context};
 use db::{client::{BlockFilter, Client}, migrations::run_migrations};
 use sb_dl::{config::Config, services::backfill::Backfiller, types::BlockInfo};
@@ -36,7 +38,6 @@ pub async fn backfill(
     let client = Client{};
     let gap_end = client.find_gap_end(&mut conn, *starting_number)?;
 
-
     for missing_block in *starting_number..gap_end {
         // get block info for the previous block which isn't missing
         let blocks = client.select_block(&mut conn, BlockFilter::Number(missing_block - 1))?;
@@ -65,6 +66,7 @@ pub async fn backfill(
                 possible_slot += 1;
             }
         }
+        tokio::time::sleep(Duration::from_secs(10)).await;
     }
 
 

--- a/crates/sb_dl/src/commands/services/backfill.rs
+++ b/crates/sb_dl/src/commands/services/backfill.rs
@@ -1,0 +1,76 @@
+use anyhow::{anyhow, Context};
+use db::{client::{BlockFilter, Client}, migrations::run_migrations};
+use sb_dl::{config::Config, services::backfill::Backfiller, types::BlockInfo};
+
+use super::downloaders::block_persistence_loop;
+
+pub async fn backfill(
+    matches: &clap::ArgMatches,
+    config_path: &str
+) -> anyhow::Result<()> {
+    let failed_blocks_dir = matches.get_one::<String>("failed-blocks").unwrap().clone();
+    let starting_number = matches.get_one::<i64>("starting-number").unwrap();
+    let cfg = Config::load(config_path).await?;
+    let conn_pool = db::new_connection_pool(&cfg.db_url)?;
+
+
+    {
+        let mut conn = conn_pool.get()?;
+        run_migrations(&mut conn);
+    }
+
+    let (blocks_tx, blocks_rx) = tokio::sync::mpsc::channel::<BlockInfo>(1000);
+
+
+    {
+        let mut conn = conn_pool.get()?;
+        // start the background persistence task
+        tokio::task::spawn(
+            async move { block_persistence_loop(&mut conn, failed_blocks_dir, blocks_rx).await },
+        );
+    }
+
+    let mut conn = conn_pool.get()?;
+
+    let backfiller = Backfiller::new(&cfg.rpc_url);
+    let client = Client{};
+    let gap_end = client.find_gap_end(&mut conn, *starting_number)?;
+
+
+    for missing_block in *starting_number..gap_end {
+        // get block info for the previous block which isn't missing
+        let blocks = client.select_block(&mut conn, BlockFilter::Number(missing_block - 1))?;
+        if blocks.is_empty() {
+            return Err(anyhow!("failed to find block"));
+        }
+        log::info!("guessing_slot(block={}, slot={:?})", blocks[0].number, blocks[0].slot);
+        let mut possible_slot = blocks[0].slot.with_context(|| "missing slot")? + 1;
+        loop {
+            if let Ok(block) = backfiller.get_block(possible_slot as u64, false).await {
+                log::info!("found missing block({possible_slot})");
+                let Some(block_height) = block.block_height else {
+                    log::warn!("missing block height");
+                    break;
+                };
+                if let Err(err) = blocks_tx.send(BlockInfo {
+                    block_height: block_height,
+                    slot: Some(possible_slot as u64),
+                    block,
+                }).await {
+                    log::error!("failed to send block {err:#?}");
+                }
+                break;
+            } else {
+                log::warn!("invalid slot({possible_slot}), trying next number...");
+                possible_slot += 1;
+            }
+        }
+    }
+
+
+
+
+
+
+    Ok(())
+}

--- a/crates/sb_dl/src/commands/services/backfill.rs
+++ b/crates/sb_dl/src/commands/services/backfill.rs
@@ -38,11 +38,11 @@ pub async fn backfill(
     let client = Client{};
     let gap_end = client.find_gap_end(&mut conn, *starting_number)?;
 
-    for missing_block in *starting_number..gap_end {
+    for missing_block in *starting_number-10..gap_end {
         // get block info for the previous block which isn't missing
         let blocks = client.select_block(&mut conn, BlockFilter::Number(missing_block - 1))?;
         if blocks.is_empty() {
-            return Err(anyhow!("failed to find block"));
+            continue;
         }
         log::info!("guessing_slot(block={}, slot={:?})", blocks[0].number, blocks[0].slot);
         let mut possible_slot = blocks[0].slot.with_context(|| "missing slot")? + 1;

--- a/crates/sb_dl/src/commands/services/downloaders.rs
+++ b/crates/sb_dl/src/commands/services/downloaders.rs
@@ -60,7 +60,7 @@ pub async fn bigtable_downloader(matches: &ArgMatches, config_path: &str) -> any
 
     // receives downloaded blocks, which allows us to persist downloaded data while we download and parse other data
     let (blocks_tx, blocks_rx) =
-        tokio::sync::mpsc::channel::<BlockInfo>(limit.unwrap_or(1_000) as usize);
+        tokio::sync::mpsc::channel::<BlockInfo>(10_000 as usize);
 
     let sig_quit = signal(SignalKind::quit())?;
     let sig_int = signal(SignalKind::interrupt())?;

--- a/crates/sb_dl/src/commands/services/downloaders.rs
+++ b/crates/sb_dl/src/commands/services/downloaders.rs
@@ -4,7 +4,7 @@ use {
     },
     anyhow::{anyhow, Context},
     clap::ArgMatches,
-    db::migrations::run_migrations,
+    db::{migrations::run_migrations, models::{BlockTableChoice, NewBlock, NewBlock2}},
     diesel::{
         prelude::*,
         r2d2::{ConnectionManager, Pool, PooledConnection},
@@ -28,7 +28,9 @@ use {
 };
 
 /// Starts the big table historical block downloader
-pub async fn bigtable_downloader(matches: &ArgMatches, config_path: &str) -> anyhow::Result<()> {
+pub async fn bigtable_downloader(matches: &ArgMatches, config_path: &str) -> anyhow::Result<()> {    
+    let blocks_table = BlockTableChoice::try_from(*matches.get_one::<u8>("block-table-choice").unwrap()).unwrap();
+
     let cfg = Config::load(config_path).await?;
     let start = matches.get_one::<u64>("start").cloned();
     let limit = matches.get_one::<u64>("limit").cloned();
@@ -52,12 +54,20 @@ pub async fn bigtable_downloader(matches: &ArgMatches, config_path: &str) -> any
         run_migrations(&mut conn);
 
         let client = db::client::Client {};
-        client
-            .indexed_blocks(&mut conn)
+        let mut blocks_1_indexed = client
+            .indexed_blocks(&mut conn, BlockTableChoice::Blocks)
             .unwrap_or_default()
             .into_iter()
             .filter_map(|block| Some(block? as u64))
-            .collect()
+            .collect::<Vec<_>>();
+        let mut blocks_2_indexed = client
+            .indexed_blocks(&mut conn, BlockTableChoice::Blocks2)
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|block| Some(block? as u64))
+            .collect::<Vec<_>>();
+        blocks_1_indexed.append(&mut blocks_2_indexed);
+        blocks_1_indexed.into_iter().collect()
     };
 
     // mark failed blocks as already indexed to avoid redownloading
@@ -76,7 +86,7 @@ pub async fn bigtable_downloader(matches: &ArgMatches, config_path: &str) -> any
 
     // start the background persistence task
     tokio::task::spawn(
-        async move { block_persistence_loop(pool, failed_blocks_dir, blocks_rx, threads).await },
+        async move { block_persistence_loop(pool, failed_blocks_dir, blocks_rx, threads, blocks_table).await },
     );
 
     let (finished_tx, finished_rx) = tokio::sync::oneshot::channel();
@@ -111,6 +121,8 @@ pub async fn bigtable_downloader(matches: &ArgMatches, config_path: &str) -> any
 
 /// Starts the geyser stream block downloader
 pub async fn geyser_stream(matches: &ArgMatches, config_path: &str) -> anyhow::Result<()> {
+    let blocks_table = BlockTableChoice::try_from(*matches.get_one::<u8>("block-table-choice").unwrap()).unwrap();
+
     let cfg = Config::load(config_path).await?;
     let failed_blocks_dir = matches.get_one::<String>("failed-blocks").unwrap().clone();
     let threads = *matches.get_one::<usize>("threads").unwrap();
@@ -146,7 +158,7 @@ pub async fn geyser_stream(matches: &ArgMatches, config_path: &str) -> anyhow::R
 
     // start the background persistence task
     tokio::task::spawn(
-        async move { block_persistence_loop(pool, failed_blocks_dir, blocks_rx, threads).await },
+        async move { block_persistence_loop(pool, failed_blocks_dir, blocks_rx, threads, blocks_table).await },
     );
 
     // optional value containing error message encountered during program execution
@@ -166,6 +178,8 @@ pub async fn geyser_stream(matches: &ArgMatches, config_path: &str) -> anyhow::R
 }
 
 pub async fn backfiller(matches: &ArgMatches, config_path: &str) -> anyhow::Result<()> {
+    let blocks_table = BlockTableChoice::try_from(*matches.get_one::<u8>("block-table-choice").unwrap()).unwrap();
+
     let cfg = Config::load(config_path).await?;
     let failed_blocks_dir = matches.get_one::<String>("failed-blocks").unwrap().clone();
     let threads = *matches.get_one::<usize>("threads").unwrap();
@@ -192,7 +206,7 @@ pub async fn backfiller(matches: &ArgMatches, config_path: &str) -> anyhow::Resu
 
     // start the background persistence task
     tokio::task::spawn(
-        async move { block_persistence_loop(pool, failed_blocks_dir, blocks_rx, threads).await },
+        async move { block_persistence_loop(pool, failed_blocks_dir, blocks_rx, threads, blocks_table).await },
     );
 
     let backfiller = Backfiller::new(&cfg.rpc_url);
@@ -216,6 +230,8 @@ pub async fn backfiller(matches: &ArgMatches, config_path: &str) -> anyhow::Resu
 }
 
 pub async fn import_failed_blocks(matches: &ArgMatches, config_path: &str) -> anyhow::Result<()> {
+    let blocks_table = BlockTableChoice::try_from(*matches.get_one::<u8>("block-table-choice").unwrap()).unwrap();
+
     let cfg = Config::load(config_path).await?;
     let failed_blocks_dir = matches.get_one::<String>("failed-blocks").unwrap().clone();
 
@@ -258,12 +274,23 @@ pub async fn import_failed_blocks(matches: &ArgMatches, config_path: &str) -> an
                         continue;
                     }
                 };
-                if let Err(err) = client.insert_block(
-                    &mut conn,
-                    block_height as i64,
-                    Some(slot_number as i64),
-                    block,
-                ) {
+                let err = match blocks_table {
+                    BlockTableChoice::Blocks => client.insert_block(
+                        &mut conn,NewBlock {
+                            number: block_height as i64,
+                            slot: Some(slot_number as i64),
+                            data: block,
+                        }
+                    ),
+                    BlockTableChoice::Blocks2 => client.insert_block(
+                        &mut conn,NewBlock2 {
+                            number: block_height as i64,
+                            slot: Some(slot_number as i64),
+                            data: block,
+                        }
+                    )
+                };
+                if let Err(err) = err {
                     log::error!("failed to insert block({slot_number}) {err:#?}");
                 } else {
                     log::info!("inserted block({slot_number})");
@@ -294,6 +321,7 @@ pub async fn block_persistence_loop(
     failed_blocks_dir: String,
     mut blocks_rx: tokio::sync::mpsc::Receiver<BlockInfo>,
     threads: usize,
+    block_table_choice: BlockTableChoice
 ) {
     let semaphore = Arc::new(Semaphore::new(threads));
 
@@ -306,7 +334,7 @@ pub async fn block_persistence_loop(
                     Ok(mut conn) => {
                         let failed_blocks_dir = failed_blocks_dir.clone();
                         tokio::task::spawn(async move {
-                            process_block(block_info, &mut conn, failed_blocks_dir, client).await;
+                            process_block(block_info, &mut conn, failed_blocks_dir, client, block_table_choice).await;
                             drop(permit);
                         });
                     }
@@ -356,7 +384,7 @@ async fn handle_exit(
     }
 }
 
-async fn process_block(block_info: BlockInfo, conn: &mut PgConnection, failed_blocks_dir: String, client: db::client::Client) {
+async fn process_block(block_info: BlockInfo, conn: &mut PgConnection, failed_blocks_dir: String, client: db::client::Client, block_table_choice: BlockTableChoice) {
     // we cant rely on parentSlot + 1, as some slots may be skipped
     let slot = if let Some(slot) = block_info.slot {
         slot
@@ -387,17 +415,25 @@ async fn process_block(block_info: BlockInfo, conn: &mut PgConnection, failed_bl
             sanitize_value(&mut block);
             // replace escaped unicode points with empty string
             sanitize_for_postgres(&mut block);
-            if client
-                .insert_block(
-                    conn,
-                    block_info.block_height as i64,
-                    Some(slot as i64),
-                    block.clone(),
+            let err: Result<(), anyhow::Error> = match block_table_choice {
+                BlockTableChoice::Blocks => client.insert_block(
+                    conn,NewBlock {
+                        number: block_info.block_height as i64,
+                        slot: Some(slot as i64),
+                        data: block.clone(),
+                    }
+                ),
+                BlockTableChoice::Blocks2 => client.insert_block(
+                    conn,NewBlock2 {
+                        number: block_info.block_height as i64,
+                        slot: Some(slot as i64),
+                        data: block.clone(),
+                    }
                 )
-                .is_err()
-            {
+            };
+            if let Err(err) = err {
                 // block persistence failed despite sanitization persist the data locally
-                log::warn!("block({slot}) persistence failed");
+                log::warn!("block({slot}) persistence failed {err:#?}");
                 match serde_json::to_string(&block) {
                     Ok(block_str) => {
                         if let Err(err) = tokio::fs::write(

--- a/crates/sb_dl/src/commands/services/mod.rs
+++ b/crates/sb_dl/src/commands/services/mod.rs
@@ -2,3 +2,4 @@ pub mod downloaders;
 pub mod idl_indexer;
 pub mod program_indexer;
 pub mod transfer_api;
+pub mod backfill;

--- a/crates/sb_dl/src/commands/transfer_graph.rs
+++ b/crates/sb_dl/src/commands/transfer_graph.rs
@@ -1,6 +1,6 @@
 use {
     anyhow::anyhow,
-    db::{client::BlockFilter, new_connection},
+    db::{client::BlockFilter, models::BlockTableChoice, new_connection},
     sb_dl::{
         config::Config,
         transfer_flow::{
@@ -22,6 +22,7 @@ pub async fn create_transfer_graph_for_tx(
     matches: &clap::ArgMatches,
     config_path: &str,
 ) -> anyhow::Result<()> {
+    log::warn!("assumes querying blocks table");
     let cfg: Config = Config::load(config_path).await?;
     // slot to pull tx from
     let slot_number = matches.get_one::<i64>("slot-number").unwrap();
@@ -29,7 +30,7 @@ pub async fn create_transfer_graph_for_tx(
     let tx_hash = matches.get_one::<String>("tx-hash").unwrap();
     let mut db_conn = new_connection(&cfg.db_url)?;
     let client = db::client::Client {};
-    let mut block = client.select_block(&mut db_conn, BlockFilter::Slot(*slot_number))?;
+    let mut block = client.select_block(&mut db_conn, BlockFilter::Slot(*slot_number), BlockTableChoice::Blocks)?;
     let block = if block.is_empty() {
         return Err(anyhow!("no block found"));
     } else {
@@ -49,13 +50,14 @@ pub async fn create_ordered_transfers_for_entire_block(
     matches: &clap::ArgMatches,
     config_path: &str,
 ) -> anyhow::Result<()> {
+    log::warn!("assumes querying blocks table");
     let cfg: Config = Config::load(config_path).await?;
     // slot to pull tx from
     let slot_number = matches.get_one::<i64>("slot-number").unwrap();
     // tx to generate graph for
     let mut db_conn = new_connection(&cfg.db_url)?;
     let client = db::client::Client {};
-    let mut block = client.select_block(&mut db_conn, BlockFilter::Slot(*slot_number))?;
+    let mut block = client.select_block(&mut db_conn, BlockFilter::Slot(*slot_number), BlockTableChoice::Blocks)?;
     let block = if block.is_empty() {
         return Err(anyhow!("no block found"));
     } else {

--- a/crates/sb_dl/src/main.rs
+++ b/crates/sb_dl/src/main.rs
@@ -48,22 +48,17 @@ async fn main() -> Result<()> {
                         )
                         .arg(no_minimization_flag())
                         .arg(failed_blocks_flag())
-                        .arg(
-                            Arg::new("threads")
-                            .long("threads")
-                            .help("number of parallel download processes to use")
-                            .value_parser(clap::value_parser!(usize))
-                            .required(false)
-                            .default_value("1")
-                        ),
+                        .arg(threads_flag()),
                     Command::new("backfiller")
                         .about("block backfiller to covers gaps missed by geyser")
                         .arg(no_minimization_flag())
-                        .arg(failed_blocks_flag()),
+                        .arg(failed_blocks_flag())
+                        .arg(threads_flag()),
                     Command::new("geyser-stream")
                         .about("stream blocks in real-time using geyser")
                         .arg(no_minimization_flag())
-                        .arg(failed_blocks_flag()),
+                        .arg(failed_blocks_flag())
+                        .arg(threads_flag()),
                     Command::new("index-idls").about("index anchor idl accounts"),
                     Command::new("index-programs").about("index deployed programs"),
                     Command::new("transfer-flow-api")
@@ -81,6 +76,7 @@ async fn main() -> Result<()> {
                         .value_parser(clap::value_parser!(i64))
                     )
                     .arg(failed_blocks_flag())
+                    .arg(threads_flag()),
                 ]),
             Command::new("import-failed-blocks").arg(failed_blocks_flag()),
             Command::new("new-config"),
@@ -226,4 +222,14 @@ fn failed_blocks_flag() -> Arg {
         .help("directory to store failed blocks in")
         .default_value("failed_blocks")
         .required(false)
+}
+
+
+fn threads_flag() -> Arg {
+    Arg::new("threads")
+    .long("threads")
+    .help("number of parallel download processes to use")
+    .value_parser(clap::value_parser!(usize))
+    .required(false)
+    .default_value("1")
 }

--- a/crates/sb_dl/src/main.rs
+++ b/crates/sb_dl/src/main.rs
@@ -110,6 +110,8 @@ async fn main() -> Result<()> {
                         .help("slot number to fetch tx from")
                         .value_parser(clap::value_parser!(i64)),
                 ),
+            Command::new("repair-invalid-slots")
+                .about("repair database entries with invalid slot numbering"),
         ])
         .get_matches();
 
@@ -148,6 +150,7 @@ async fn process_matches(matches: &ArgMatches, config_path: &str) -> anyhow::Res
             commands::transfer_graph::create_ordered_transfers_for_entire_block(cotfb, config_path)
                 .await
         }
+        Some(("repair-invalid-slots", _)) => commands::db::repair_invalid_slots(config_path).await,
         Some(("services", s)) => match s.subcommand() {
             Some(("bigtable-downloader", bd)) => {
                 commands::services::downloaders::bigtable_downloader(bd, config_path).await

--- a/crates/sb_dl/src/main.rs
+++ b/crates/sb_dl/src/main.rs
@@ -105,6 +105,14 @@ async fn main() -> Result<()> {
                         .help("number of blocks to fill at once")
                         .value_parser(clap::value_parser!(i64)),
                 ),
+            Command::new("fill-missing-slots-no-tx")
+            .about("fill missing slots for blocks with no non-vote transactions")
+            .arg(
+                Arg::new("limit")
+                    .long("limit")
+                    .help("number of blocks to fill at once")
+                    .value_parser(clap::value_parser!(i64)),
+            ),
             Command::new("create-transfer-graph-for-tx")
                 .about("generate transfer graph for a single tx")
                 .arg(
@@ -176,6 +184,7 @@ async fn process_matches(matches: &ArgMatches, config_path: &str) -> anyhow::Res
         }
         Some(("repair-invalid-slots", _)) => commands::db::repair_invalid_slots(config_path).await,
         Some(("find-gap-end", fge)) => commands::db::find_gap_end(fge, config_path).await,
+        Some(("fill-missing-slots-no-tx", fmsnt)) => commands::db::fill_missing_slots_no_tx(fmsnt, config_path).await,
         Some(("services", s)) => match s.subcommand() {
             Some(("bigtable-downloader", bd)) => {
                 commands::services::downloaders::bigtable_downloader(bd, config_path).await

--- a/crates/sb_dl/src/main.rs
+++ b/crates/sb_dl/src/main.rs
@@ -47,7 +47,15 @@ async fn main() -> Result<()> {
                                 .required(false),
                         )
                         .arg(no_minimization_flag())
-                        .arg(failed_blocks_flag()),
+                        .arg(failed_blocks_flag())
+                        .arg(
+                            Arg::new("threads")
+                            .long("threads")
+                            .help("number of parallel download processes to use")
+                            .value_parser(clap::value_parser!(usize))
+                            .required(false)
+                            .default_value("1")
+                        ),
                     Command::new("backfiller")
                         .about("block backfiller to covers gaps missed by geyser")
                         .arg(no_minimization_flag())

--- a/crates/sb_dl/src/services/geyser.rs
+++ b/crates/sb_dl/src/services/geyser.rs
@@ -24,6 +24,9 @@ pub async fn new_geyser_client(
         .x_token(token.to_string().into())?
         .connect_timeout(Duration::from_secs(10))
         .timeout(Duration::from_secs(10))
+        .keep_alive_while_idle(true)
+        .http2_keep_alive_interval(Duration::from_secs(10))
+        .keep_alive_timeout(Duration::from_secs(20))
         .max_decoding_message_size(max_decoding_size)
         .max_encoding_message_size(max_encoding_size)
         .tcp_nodelay(true)

--- a/crates/sb_dl/src/services/transfer_flow_api.rs
+++ b/crates/sb_dl/src/services/transfer_flow_api.rs
@@ -33,7 +33,7 @@ pub async fn serve_api(listen_url: &str, db_url: &str) -> anyhow::Result<()> {
 }
 
 pub fn new_router(db_url: &str) -> anyhow::Result<Router> {
-    let db_pool = new_connection_pool(db_url)?;
+    let db_pool = new_connection_pool(db_url, 10)?;
     let app = Router::new()
         .route(
             "/orderedTransfers/:blockNumber",

--- a/crates/storage-bigtable/Cargo.toml
+++ b/crates/storage-bigtable/Cargo.toml
@@ -3,7 +3,7 @@ name = "solana-storage-bigtable"
 description = "Solana Storage BigTable"
 documentation = "https://docs.rs/solana-storage-bigtable"
 edition = "2021"
-
+version = "0.1.0"
 [dependencies.backoff]
 version = "0.4"
 features = ["tokio"]

--- a/crates/storage-bigtable/build-proto/Cargo.toml
+++ b/crates/storage-bigtable/build-proto/Cargo.toml
@@ -2,6 +2,7 @@
 description = "Blockchain, Rebuilt for Scale"
 name = "proto"
 edition = "2021"
+version = "0.1.0"
 
 [dependencies.tonic-build]
 version = "0.11"


### PR DESCRIPTION
# Overview

* Add cli command to repair database entries for blocks indexed before proper slot calculation was added.
* There is an edge case if a block contains no non-voting transactions, this will need to be manually corrected