### PR TITLE
Set Rust Version Before Compiling CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,8 @@
 [workspace]
 resolver = "2"
 members = [ "crates/db", "crates/sb_dl", "crates/storage-bigtable", "crates/storage-bigtable/build-proto"]
+[workspace.package]
+rust-version = "1.78"
 [profile.release]
 opt-level = 3
 lto = "fat"

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 .PHONY: cli
 cli:
+	rustup default 1.78
 	cargo build --bin sb_dl
 	cp target/debug/sb_dl .
 
 .PHONY: cli-release
 cli-release:
+	rustup default 1.78
 	cargo build --release --bin sb_dl
 	cp target/release/sb_dl .
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -17,6 +17,8 @@ cd "$dir"; cd ..
 echo "********************************************************************************"
 echo "* Build sb_dl"
 echo "********************************************************************************"
+# use specific rustc version to avoid illegal hardware instruction errors
+rustup default 1.78
 make cli-release
 
 echo ""


### PR DESCRIPTION
# Overview

When using rustc 1.82, random failures occur due to "illegal hardware instruction" errors. This does not happen when using rustc 1.78.

As a short-term solution, whenever building the CLI, or running the deployment script force the rustc version to 1.78