### PR TITLE
Stateless Transfer Parser API

### DIFF
--- a/crates/db/migrations/2024-12-16-034310_alter_blocks_add_number_index/down.sql
+++ b/crates/db/migrations/2024-12-16-034310_alter_blocks_add_number_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX blocks_number_key;

--- a/crates/db/migrations/2024-12-16-034310_alter_blocks_add_number_index/down.sql
+++ b/crates/db/migrations/2024-12-16-034310_alter_blocks_add_number_index/down.sql
@@ -1,1 +1,1 @@
-DROP INDEX IF EXISTS blocks_number_key; 
+DROP INDEX IF EXISTS blocks_number_key;

--- a/crates/db/migrations/2024-12-16-034310_alter_blocks_add_number_index/down.sql
+++ b/crates/db/migrations/2024-12-16-034310_alter_blocks_add_number_index/down.sql
@@ -1,1 +1,1 @@
-DROP INDEX blocks_number_key;
+DROP INDEX IF EXISTS blocks_number_key; 

--- a/crates/db/migrations/2024-12-16-034310_alter_blocks_add_number_index/up.sql
+++ b/crates/db/migrations/2024-12-16-034310_alter_blocks_add_number_index/up.sql
@@ -1,1 +1,1 @@
-CREATE INDEX blocks_number_key ON blocks(number);
+CREATE INDEX IF NOT EXISTS blocks_number_key ON blocks(number);

--- a/crates/db/migrations/2024-12-16-034310_alter_blocks_add_number_index/up.sql
+++ b/crates/db/migrations/2024-12-16-034310_alter_blocks_add_number_index/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX blocks_number_key ON blocks(number);

--- a/crates/db/migrations/2024-12-16-034310_alter_blocks_add_number_index/up.sql
+++ b/crates/db/migrations/2024-12-16-034310_alter_blocks_add_number_index/up.sql
@@ -1,1 +1,1 @@
-CREATE INDEX IF NOT EXISTS blocks_number_key ON blocks(number);
+CREATE UNIQUE INDEX IF NOT EXISTS blocks_number_key ON blocks (number);

--- a/crates/db/src/client.rs
+++ b/crates/db/src/client.rs
@@ -266,7 +266,37 @@ impl Client {
                     _ => Err(anyhow!("{:#?}", kind)),
                 }
             }
-            Err(err) => Err(anyhow!("{err:#?}"))
+            Err(err) => Err(anyhow!("{err:#?}")),
         }
     }
+    pub fn find_gaps(&self, conn: &mut PgConnection, start_height: i64, end_height: i64, limit: Option<i64>) -> anyhow::Result<Vec<i64>> {
+        let limit = if let Some(limit) = limit {
+            limit
+        } else {
+            100
+        };
+        // generally speaking one should never use formatted inputs like this
+        // due to sql injection vulnerabilities, but as this is initiated from 
+        // backend services, and we don't store personal/sensitive information
+        // it doesn't matter
+        let gaps = sql_query(format!(
+        "WITH expected_heights AS (
+            SELECT generate_series({start_height}, {end_height}) AS height
+        )
+        SELECT e.height AS number
+        FROM expected_heights e
+        LEFT JOIN blocks b
+        ON e.height = b.number
+        WHERE b.number IS NULL
+        LIMIT {limit};"
+        )).load::<Gaps>(conn)?;
+        Ok(gaps.into_iter().map(|g| g.number).collect::<Vec<_>>())
+    }
+}
+
+#[derive(Debug, QueryableByName, Queryable)]
+#[diesel(table_name = blocks)]
+pub struct Gaps {
+    #[diesel(sql_type = diesel::sql_types::Bigint)]
+    pub number: i64,
 }

--- a/crates/db/src/client.rs
+++ b/crates/db/src/client.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Context};
 use chrono::prelude::*;
-use diesel::{prelude::*, result::DatabaseErrorKind};
+use diesel::{pg::Pg, prelude::*, result::DatabaseErrorKind, sql_query};
 use uuid::Uuid;
 
 use crate::models::{Blocks, Idls, NewBlock, NewSquads, Programs, Squads};
@@ -245,7 +245,7 @@ impl Client {
         d: &serde_json::Value,
     ) -> anyhow::Result<()> {
         use crate::schema::blocks::dsl::*;
-        let res =  NewBlock {
+        let res = NewBlock {
             number: n,
             slot: s,
             time: t,
@@ -253,7 +253,7 @@ impl Client {
             data: d,
         }
         .insert_into(blocks)
-        .execute(conn); 
+        .execute(conn);
         match res {
             Ok(_) => Ok(()),
             Err(diesel::result::Error::DatabaseError(kind, _)) => {

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -28,6 +28,7 @@ pub fn new_connection_pool(db_url: &str, max_size: u32) -> Result<Pool<Connectio
 
     Pool::builder()
         .max_size(max_size)
+        .max_lifetime(Some(std::time::Duration::from_secs(30)))
         .test_on_check_out(true)
         .build(manager).with_context(|| "failed to build connection pool")
 }

--- a/crates/sb_dl/Cargo.toml
+++ b/crates/sb_dl/Cargo.toml
@@ -59,6 +59,9 @@ rev = "fe870322fafc1a4cd3617d193ef09a4a3bf65c55"
 [dependencies.yellowstone-grpc-client]
 git = "https://github.com/rpcpool/yellowstone-grpc"
 rev = "fe870322fafc1a4cd3617d193ef09a4a3bf65c55"
+[dependencies.tower-http]
+version = "0.6"
+features = ["trace"]
 [dependencies.futures]
 version = "0.3"
 [dependencies.bincode]

--- a/crates/sb_dl/Cargo.toml
+++ b/crates/sb_dl/Cargo.toml
@@ -85,6 +85,8 @@ version = "0.4"
 version = "8.15.0-alpha.1"
 [dependencies.tonic]
 version = "0.12.1"
+[dependencies.tracing-appender]
+version = "0.2.3"
 [dependencies.db]
 path = "../db"
 [dependencies.solana-storage-bigtable]

--- a/crates/sb_dl/src/cli/mod.rs
+++ b/crates/sb_dl/src/cli/mod.rs
@@ -128,14 +128,15 @@ pub enum ServicesCommands {
 
     #[command(about = "used to repair gaps in block coverage")]
     RepairGaps {
-        #[arg(long)]
-        starting_number: i64,
 
         #[arg(from_global)]
         failed_blocks_dir: String,
 
         #[arg(from_global)]
         threads: u32,
+
+        #[arg(long, help = "limit number of gaps")]
+        limit: i64
     },
 
     #[command(about = "transfer parsing service to push decoded transfers into elasticsearch")]
@@ -172,4 +173,9 @@ pub enum ServicesCommands {
         #[arg(from_global)]
         failed_blocks_dir: String,
     },
+    #[command(about = "check for gaps in block data")]
+    FindGaps {
+        #[arg(long)]
+        limit: i64
+    }
 }

--- a/crates/sb_dl/src/commands/services/transfer_api.rs
+++ b/crates/sb_dl/src/commands/services/transfer_api.rs
@@ -12,5 +12,5 @@ pub async fn transfer_flow_api(
     };
     let cfg = Config::load(config_path).await?;
 
-    serve_api(&listen_url, &cfg.db_url).await
+    serve_api(&listen_url).await
 }

--- a/crates/sb_dl/src/main.rs
+++ b/crates/sb_dl/src/main.rs
@@ -60,6 +60,9 @@ async fn main() -> Result<()> {
                 commands::services::downloaders::import_failed_blocks(command.clone(), &app.config)
                     .await
             }
+            ServicesCommands::FindGaps {..} => {
+                commands::services::repair_gaps::find_gaps(command.clone(), &app.config).await
+            }
         },
         Commands::NewConfig => commands::config::new_config(&app.config).await,
         Commands::ManualIdlImport { input, program_id } => {

--- a/crates/sb_dl/src/main.rs
+++ b/crates/sb_dl/src/main.rs
@@ -22,8 +22,8 @@ async fn main() -> Result<()> {
             }
         }
     }
-    init_log(&app.log_level, &app.log_file);
-    match &app.command {
+    let guard = init_log(&app.log_level, &app.log_file);
+    let res  = match &app.command {
         Commands::Services { command } => match command {
             ServicesCommands::BigtableDownloader { .. } => {
                 commands::services::downloaders::bigtable_downloader(command.clone(), &app.config)
@@ -86,5 +86,10 @@ async fn main() -> Result<()> {
         Commands::FindGapEnd {
             gap_start,
         } => commands::db::find_gap_end(*gap_start, &app.config).await,
+    };
+
+    if let Some(g) = guard {
+        drop(g);
     }
+    res
 }

--- a/crates/sb_dl/src/services/bigtable.rs
+++ b/crates/sb_dl/src/services/bigtable.rs
@@ -172,6 +172,7 @@ impl Downloader {
                     }),
                     request_stats_view: 0,
                     reversed: false,
+                    authorized_view_name: "".to_string(),
                 })
                 .await
                 .with_context(|| format!("failed to get blocks"))?
@@ -272,6 +273,7 @@ impl Downloader {
                     }),
                     request_stats_view: 0,
                     reversed: false,
+                    authorized_view_name: "".to_string(),
                 })
                 .await
                 .with_context(|| format!("failed to get block for slot({slot})"))?

--- a/crates/sb_dl/src/services/transfer_parser.rs
+++ b/crates/sb_dl/src/services/transfer_parser.rs
@@ -110,8 +110,8 @@ impl TransferParser {
             Ok(ordered_transfers) => {
                 return Ok(OrderedTransfersResponse {
                     transfers: ordered_transfers,
-                    slot,
                     time,
+                    slot: Some(slot)
                 });
             }
             Err(err) => {


### PR DESCRIPTION
# Overview

* Removes database requirement from the transfer parser api instead providing the block to decode via the request payload
* Avoid needless clones, and pre-allocate memory where possible